### PR TITLE
[Dependencies] [Security] Updating the dependencies to latest version 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 
 ##############################################################
 # Stage: builder
-FROM ruby:2.6.5-alpine3.10 AS builder
+FROM ruby:3.0.1-alpine3.13 AS builder
 
 WORKDIR /app
 
@@ -32,7 +32,7 @@ RUN cd dashboard && npm install --no-optional && npm rebuild node-sass && node_m
 
 ##############################################################
 # Stage: final
-FROM ruby:2.6.5-alpine3.10
+FROM ruby:3.0.1-alpine3.13
 
 LABEL org="Appvia Ltd"
 LABEL website="appvia.io"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ version: '3.7'
 services:
 
   redisgraph:    
-    image: redislabs/redisgraph:1.99.7    
+    image: redislabs/redisgraph:2.1.0   
     container_name: redisgraph
     ports:
       - 6379:6379


### PR DESCRIPTION
The outdated dependencies have 130 total vulnerabilities. Updating the dependencies fixes them. 
