### PR TITLE
Ensure bundler version used to generate gemfile.lock is installed in …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ RUN apk add --update --no-cache git bash curl make gcc libc-dev tzdata g++ npm
 # copy app
 COPY . /app
 
+# install bundler
+RUN gem install bundler --no-document -v $(cat Gemfile.lock | tail -n 1 | xargs)
+
 # install gems
 RUN bundle config set deployment 'true'
 RUN bundle config set without 'development test'


### PR DESCRIPTION
…the docker image

Previously it would use the default bundler version for the base ruby image which may be older that the bundler version used to generated the lock.