### PR TITLE
Fix: unrestricted-access rules report 'resources' instead of naming the subject

### DIFF
--- a/lib/krane/report/risk_rule/resolver.rb
+++ b/lib/krane/report/risk_rule/resolver.rb
@@ -88,14 +88,14 @@ module Krane
         # Note: :query has precedence over :template
         def query
           return if @item[:query].present?     # when :query excplicitly defined then no need to resolve matchers
-          @item[:query] = cleanup(Query::Builder.for(item: @item))
+          @item[:query] = cleanup_query(Query::Builder.for(item: @item))
         end
 
         # Resolves writer based on :template defined for the risk rule item (only when no explicit :writer is provided)
         # Note: :writer has precedence over :template!
         def writer
           return if @item[:writer].present?   # when :writer explicitly defined then no need to resolve it
-          @item[:writer] = cleanup(Query::Template.for(kind: @item[:template]).writer)
+          @item[:writer] = cleanup_writer(Query::Template.for(kind: @item[:template]).writer)
         end
 
         def custom_params
@@ -168,8 +168,22 @@ module Krane
           str.gsub!("{{#{placeholder}}}") { value }
         end
 
-        def cleanup str
+        # Normalises a resolved graph query. Newlines carry no meaning in Cypher, so the whole
+        # query is squeezed onto a single line.
+        def cleanup_query str
           str.strip.gsub(/\s+/, ' ')
+        end
+
+        # Normalises a resolved writer expression.
+        #
+        # A writer is Ruby source, not a query, so its newlines ARE significant and must be kept.
+        # Squeezing them merges consecutive statements onto one line, and Ruby's adjacent string
+        # literal concatenation then absorbs a trailing message string into the preceding
+        # statement - leaving the writer to evaluate to that statement's value rather than the
+        # message. Only the heredoc indentation is removed here; content within a line is left
+        # alone, and the writer's *output* is separately whitespace-normalised in Report::Element.
+        def cleanup_writer str
+          str.strip.lines.map(&:strip).join("\n")
         end
       
       end

--- a/spec/lib/krane/report/risk_rule/resolver_spec.rb
+++ b/spec/lib/krane/report/risk_rule/resolver_spec.rb
@@ -101,6 +101,59 @@ RSpec.describe Krane::Report::RiskRule::Resolver do
 
       end
 
+      # A writer is Ruby source, so collapsing its newlines changes what it evaluates to.
+      # The two `unrestricted-*` templates use a two-line writer - an assignment followed by
+      # the message string - and Ruby's adjacent string literal concatenation absorbs the
+      # message into the assignment when they end up on one line, leaving the writer to
+      # evaluate to the assigned value instead of the message.
+      context 'for a template whose writer spans multiple lines' do
+
+        let(:risk) do
+          build(
+            :risk,
+            :with_default_template_based_rule,
+            default_rule_template: 'unrestricted-ns-level-subjects'
+          )
+        end
+
+        let(:result) do
+          Hashie::Mash.new(
+            rule_type:      'resource',
+            subject_kind:   'User',
+            subject_name:   'bob',
+            rule_api_group: '*',
+            namespace_name: 'team-a'
+          )
+        end
+
+        it 'preserves the newlines in the resolved writer' do
+          expect(subject.risk_rules.first.writer).to include("\n")
+        end
+
+        it 'resolves to a writer which evaluates to the risk message' do
+          writer = subject.risk_rules.first.writer
+
+          expect(eval(writer)).to eq(
+            'User bob has * access to * resources (apiGroup: *) in team-a namespace'
+          )
+        end
+
+        context 'for a non-resource rule' do
+
+          let(:result) { super().merge(rule_type: 'non-resource') }
+
+          it 'resolves to a writer which evaluates to the risk message' do
+            writer = subject.risk_rules.first.writer
+
+            expect(eval(writer)).to eq(
+              'User bob has * access to * non-resource URLs (apiGroup: *) in team-a namespace'
+            )
+          end
+
+        end
+
+      end
+
     end
 
     context 'with query based risk rule without both query & writer specified' do


### PR DESCRIPTION
## Problem

A risk rule's `writer` is Ruby source, but `Resolver#cleanup` normalised it with the same
`gsub(/\s+/, ' ')` used for graph queries. Newlines are insignificant in Cypher and **significant in
Ruby**, so collapsing them merged consecutive statements onto one line.

Two built-in templates use a two-line writer — an assignment followed by the message string:

```ruby
txt = result.rule_type == 'resource' ? 'resources' : 'non-resource URLs'
"#{result.subject_kind} #{result.subject_name} has * access to * #{txt} (apiGroup: ...)"
```

Once on one line, Ruby's adjacent string literal concatenation absorbs the message into the ternary's
else-branch, so the whole expression is a single assignment whose value is `txt`.

Both affected rules are the **unrestricted access** checks — arguably the most important findings
krane produces, and `subjects-with-open-cluster-wide-access` is `:danger`, so it fails `--ci`.
`Report::Element#query_result_items` also calls `.uniq` on writer output, so *every* matching subject
collapsed into a single item.

## Impact

Real output, from a fixture with four over-privileged subjects:

**Before**
```
[danger]  subjects-with-open-cluster-wide-access
    - resources
[warning] subjects-with-open-ns-level-access
    - resources
```

**After**
```
[danger]  subjects-with-open-cluster-wide-access
    - User carol has * access to * resources (apiGroup: *)
    - Group sre-team has * access to * resources (apiGroup: *)
[warning] subjects-with-open-ns-level-access
    - User alice has * access to * resources (apiGroup: *) in team-a namespace
    - User bob has * access to * resources (apiGroup: *) in team-a namespace
```

The finding fired and the CI exit code was correct, but the report could not say **who** had
unrestricted access — which is the entire point of those two rules.

## Fix

Rather than add a `;` to the two templates — which would fix today's two and leave the trap armed for
the next multi-line one — `cleanup` is split by language:

- `cleanup_query` — squeezes all whitespace (newlines carry no meaning in Cypher).
- `cleanup_writer` — strips heredoc indentation only, preserving newlines and leaving content within
  a line untouched.

Writer *output* is still whitespace-normalised in `Report::Element`, so nothing downstream changes.

## Verification

- 3 new specs, written failing first, covering both the mechanism (newlines survive resolution) and
  the symptom (the writer evaluates to the message), including the `non-resource` branch.
- Full suite: **136 examples, 0 failures**.
- Executed end to end against **RedisGraph 2.6.1** via `krane report --dir` — the before/after output
  above is real, not illustrative.
- No new RuboCop `Lint`/`Security` offences.

## Scope note

`Resolver#writer` returns early when a rule defines an explicit `writer`, so multi-line writers in a
user's `custom-rules.yaml` never reached `cleanup` and were never affected. The blast radius was the
two built-in templates only.

## Review notes

Independent of the other two PRs in this series — different files, no overlap. Safe to merge in any
order relative to them.
