### PR TITLE
Fix: include namespace in the identity of namespace-scoped RBAC objects

### DIFF
--- a/lib/krane/rbac/graph/builder.rb
+++ b/lib/krane/rbac/graph/builder.rb
@@ -51,6 +51,13 @@ module Krane
         ALL_NAMESPACES_PLACEHOLDER = '*'
         NODE_LABEL_PREFIX = 'n'
 
+        # RBAC kinds which are namespace scoped. Objects of these kinds are only unique
+        # within a namespace, so the namespace must form part of their graph node identity.
+        # Without it, same-named objects in different namespaces collapse into a single
+        # node and their access rules merge.
+        # Note: ClusterRole is cluster scoped, and User/Group are not namespaced in RBAC.
+        NAMESPACED_KINDS = [:Role, :ServiceAccount].freeze
+
         attr_reader :defined_roles, :undefined_roles, :bindings_without_subject
 
         # New graph builder instance
@@ -62,7 +69,9 @@ module Krane
         def initialize path:, options: nil
           @path                     = path
           @options                  = options
-          @role_ns_lookup           = {}      # Internal lookup for Role's namespace
+          # Internal lookup mapping a Role name to the set of namespaces it is defined in.
+          # A role name is only unique within a namespace, so this cannot be a single value.
+          @role_ns_lookup           = Hash.new { |h, k| h[k] = Set.new }
           @node_weights             = Hash.new { |h, k| h[k] = 0 } # holds information on Node weight (more weight to popular nodes)
           @labels                   = {}      # List all labels and their respective ID
           @labels_counter           = 0       # Internal initial ID counter for labels 
@@ -127,6 +136,49 @@ module Krane
         memoize def make_label *str
           label = str.flatten.compact.join('_').downcase.gsub(/\W/,'_')
           @labels[label] ||= "#{NODE_LABEL_PREFIX}#{(@labels_counter += 1)}"
+        end
+
+        # Generates a graph node label for an RBAC entity, including its namespace when the
+        # entity's kind is namespace scoped. This is the single place that decides what makes
+        # up an entity's graph identity - node and edge builders must both go through it, or
+        # an edge will reference a label that no node declares.
+        #
+        # @param kind [Symbol/String] entity kind (:Role, :ClusterRole, :ServiceAccount, :User, :Group)
+        # @param name [String] entity name
+        # @param namespace [String] the entity's own namespace. Ignored for cluster scoped kinds.
+        #
+        # @return [String]
+        def label_for kind, name, namespace = nil
+          return make_label kind, name unless namespaced? kind
+          make_label kind, name, namespace
+        end
+
+        # Returns whether entities of the given kind are namespace scoped
+        #
+        # @param kind [Symbol/String] entity kind
+        #
+        # @return [Boolean]
+        def namespaced? kind
+          NAMESPACED_KINDS.include? kind.to_s.to_sym
+        end
+
+        # Returns the identity of a role for set membership and lookup purposes
+        # (@defined_roles, @default_roles, @referenced_roles, @undefined_roles).
+        #
+        # This must agree with #label_for on what makes a role distinct, otherwise the role
+        # bookkeeping and the graph disagree - e.g. a Role defined in one namespace would be
+        # treated as satisfying a binding that references the same name in another namespace,
+        # leaving edges pointing at a graph node that was never created.
+        #
+        # @param kind [Symbol/String] :Role or :ClusterRole
+        # @param name [String] role name
+        # @param namespace [String] the role's own namespace. Ignored for :ClusterRole.
+        #
+        # @return [Hash]
+        def role_identity kind, name, namespace = nil
+          identity = { role_kind: kind.to_s.to_sym, role_name: name }
+          identity[:role_namespace] = namespace if namespaced? kind
+          identity
         end
 
       end

--- a/lib/krane/rbac/graph/concerns/bindings.rb
+++ b/lib/krane/rbac/graph/concerns/bindings.rb
@@ -62,10 +62,11 @@ module Krane
               
               # If role in binding hasn't been defined then it should be recorded
               attrs = {
-                role_kind:    role_kind, 
-                role_name:    role_name, 
-                binding_kind: binding_kind, 
-                binding_name: binding_name 
+                role_kind:    role_kind,
+                role_name:    role_name,
+                binding_kind: binding_kind,
+                binding_name: binding_name,
+                namespace:    namespace
               }
               register_undefined_role(**attrs)
               
@@ -104,10 +105,12 @@ module Krane
             def set_relation_between_any_two_subjects subjects:
               subjects.combination(2).each do |a,b|
                 edge :relation, {
-                  a_subject_kind: a['kind'],
-                  a_subject_name: a['name'],
-                  b_subject_kind: b['kind'],
-                  b_subject_name: b['name'],
+                  a_subject_kind:      a['kind'],
+                  a_subject_name:      a['name'],
+                  a_subject_namespace: a['namespace'],
+                  b_subject_kind:      b['kind'],
+                  b_subject_name:      b['name'],
+                  b_subject_namespace: b['namespace'],
                 }
               end
             end
@@ -123,36 +126,53 @@ module Krane
             #
             # @return [nil]
             def set_subject_relations subject:, role_kind:, role_name:, binding_namespace: nil
-              # subject namespace is determined in the following priority order:
+              # The namespace the subject is being granted access to, determined in the
+              # following priority order:
               # 1. role binding namespace
-              # 2. role namespace
+              # 2. role namespace, when the role name is defined in exactly one namespace
               # 3. if all above nil it defaults to ALL_NAMESPACES_PLACEHOLDER
-              subject_namespace = if binding_namespace.present?
+              #
+              # Note this is NOT the subject's own namespace - a ServiceAccount defined in one
+              # namespace can be granted access to a different one.
+              access_namespace = if binding_namespace.present?
                 binding_namespace
               else
-                @role_ns_lookup.fetch(role_name, Krane::Rbac::Graph::Builder::ALL_NAMESPACES_PLACEHOLDER)
+                role_namespaces = @role_ns_lookup.fetch(role_name, nil)
+                # A role name defined in several namespaces cannot be attributed to one of
+                # them, so fall back to the cluster-wide placeholder rather than guessing.
+                role_namespaces&.size == 1 ? role_namespaces.first :
+                  Krane::Rbac::Graph::Builder::ALL_NAMESPACES_PLACEHOLDER
               end
 
-              # Building up referenced roles
-              @referenced_roles << {
-                role_kind: role_kind.to_sym, 
-                role_name: role_name
+              # The subject's own namespace, which forms part of its graph identity.
+              # Only present for ServiceAccount subjects.
+              subject_namespace = subject['namespace']
+
+              # Building up referenced roles. Must use the same identity as @defined_roles,
+              # otherwise `unused_roles` (defined - default - referenced) stops matching.
+              @referenced_roles << role_identity(role_kind, role_name, access_namespace)
+
+              node :namespace, { name: access_namespace }
+              node :subject, {
+                kind:      subject['kind'],
+                name:      subject['name'],
+                namespace: subject_namespace
               }
 
-              node :namespace, { name: subject_namespace }
-              node :subject, { kind: subject['kind'], name: subject['name'] }
-              
-              edge :assign, { 
-                role_kind: role_kind, 
-                role_name: role_name, 
-                subject_kind: subject['kind'], 
-                subject_name: subject['name'] 
+              edge :assign, {
+                role_kind:         role_kind,
+                role_name:         role_name,
+                role_namespace:    access_namespace,
+                subject_kind:      subject['kind'],
+                subject_name:      subject['name'],
+                subject_namespace: subject_namespace
               }
 
               edge :access, {
-                subject_kind: subject['kind'], 
-                subject_name: subject['name'], 
-                namespace: subject_namespace 
+                subject_kind:      subject['kind'],
+                subject_name:      subject['name'],
+                subject_namespace: subject_namespace,
+                namespace:         access_namespace
               }
             end
 
@@ -162,24 +182,21 @@ module Krane
             # @param role_name [String] - role name
             # @param binding_kind [Symbol] - binding kind as :RoleBinding, :ClusterRoleBinding
             # @param binding_name [String] - binding name
+            # @param namespace [String] - namespace the binding refers the role in
             #
             # @return [nil]
-            def register_undefined_role role_kind:, role_name:, binding_kind:, binding_name:
-              return if @defined_roles.find do |r| 
-                r[:role_kind] == role_kind.to_sym && r[:role_name] == role_name
-              end
+            def register_undefined_role role_kind:, role_name:, binding_kind:, binding_name:, namespace: nil
+              return if @defined_roles.include? role_identity(role_kind, role_name, namespace)
 
               # Add role to undefined roles dict
-              @undefined_roles << { 
-                role_kind:    role_kind, 
-                role_name:    role_name, 
-                binding_kind: binding_kind, 
-                binding_name: binding_name 
-              } 
+              @undefined_roles << role_identity(role_kind, role_name, namespace).merge(
+                binding_kind: binding_kind,
+                binding_name: binding_name
+              )
 
               # Create missing Role node so it can be referred to by other entities
               # Missing Role node must have attribute {defined: 'false'} so we can filter it in queries
-              node :role, { kind: role_kind, name: role_name, defined: false }
+              node :role, { kind: role_kind, name: role_name, namespace: namespace, defined: false }
             end
 
             # Caches bindings without any subjects

--- a/lib/krane/rbac/graph/concerns/edges.rb
+++ b/lib/krane/rbac/graph/concerns/edges.rb
@@ -77,11 +77,12 @@ module Krane
             #
             # @param role_kind [Symbol/String] :Role or :ClusterRole
             # @param role_name [String] - role name
-            # @param namespace [String] - namespace name
+            # @param namespace [String] - namespace name. For a :Role this is also the role's
+            #                             own namespace, so it forms part of the role's identity.
             #
             # @return [nil]
             def edge_scope role_kind:, role_name:, namespace:
-              role_label = make_label role_kind, role_name
+              role_label = label_for role_kind, role_name, namespace
               ns_label   = make_label namespace
 
               add_relation role_label, :SCOPE, ns_label
@@ -92,11 +93,14 @@ module Krane
             #
             # @param subject_kind [Symbol/String] :User, :Group, :ServiceAccount
             # @param subject_name [String] - subject name
-            # @param namespace [String] - namespace name
+            # @param namespace [String] - the namespace the subject is being granted access to
+            # @param subject_namespace [String] - the subject's own namespace. Distinct from
+            #                                     :namespace above - a ServiceAccount in one
+            #                                     namespace can be granted access to another.
             #
             # @return [nil]
-            def edge_access subject_kind:, subject_name:, namespace:
-              subject_label = make_label subject_kind, subject_name
+            def edge_access subject_kind:, subject_name:, namespace:, subject_namespace: nil
+              subject_label = label_for subject_kind, subject_name, subject_namespace
               ns_label      = make_label namespace
 
               add_relation subject_label, :ACCESS, ns_label
@@ -107,10 +111,11 @@ module Krane
             # @param role_kind [Symbol/String] :Role, :ClusterRole
             # @param role_name [String] - role name
             # @param rule [Hash] - access rule definition map
+            # @param namespace [String] - the role's own namespace
             #
             # @return [nil]
-            def edge_grant role_kind:, role_name:, rule:
-              role_label = make_label role_kind, role_name
+            def edge_grant role_kind:, role_name:, rule:, namespace: nil
+              role_label = label_for role_kind, role_name, namespace
               rule_label = make_label rule.values
 
               add_relation role_label, :GRANT, rule_label
@@ -139,11 +144,14 @@ module Krane
             # @param role_name [String] - role name
             # @param subject_kind [Symbol/String] :User, :Group, :ServiceAccount
             # @param subject_name [String] - subject name
+            # @param role_namespace [String] - the role's own namespace
+            # @param subject_namespace [String] - the subject's own namespace
             #
             # @return [nil]
-            def edge_assign role_kind:, role_name:, subject_kind:, subject_name:
-              role_label    = make_label role_kind, role_name
-              subject_label = make_label subject_kind, subject_name
+            def edge_assign role_kind:, role_name:, subject_kind:, subject_name:,
+                role_namespace: nil, subject_namespace: nil
+              role_label    = label_for role_kind, role_name, role_namespace
+              subject_label = label_for subject_kind, subject_name, subject_namespace
 
               add_relation role_label, :ASSIGN, subject_label
             end
@@ -154,11 +162,14 @@ module Krane
             # @param a_subject_name [String] - first subject name
             # @param b_subject_kind [Symbol/String] :User, :Group, :ServiceAccount
             # @param b_subject_name [String] - second subject name
+            # @param a_subject_namespace [String] - first subject's own namespace
+            # @param b_subject_namespace [String] - second subject's own namespace
             #
             # @return [nil]
-            def edge_relation a_subject_kind:, a_subject_name:, b_subject_kind:, b_subject_name:
-              a_subject_label = make_label a_subject_kind, a_subject_name
-              b_subject_label = make_label b_subject_kind, b_subject_name
+            def edge_relation a_subject_kind:, a_subject_name:, b_subject_kind:, b_subject_name:,
+                a_subject_namespace: nil, b_subject_namespace: nil
+              a_subject_label = label_for a_subject_kind, a_subject_name, a_subject_namespace
+              b_subject_label = label_for b_subject_kind, b_subject_name, b_subject_namespace
 
               add_relation a_subject_label, :RELATION, b_subject_label
             end

--- a/lib/krane/rbac/graph/concerns/nodes.rb
+++ b/lib/krane/rbac/graph/concerns/nodes.rb
@@ -78,6 +78,8 @@ module Krane
             #
             # @param kind [Symbol] - kind of node to be created
             # @param name [String] - kind of node to be created
+            # @param namespace [String] - the role's own namespace. Part of the node identity
+            #                             for :Role; ignored for the cluster scoped :ClusterRole.
             # @param version [String] - kind of node to be created
             # @param created_at [String] - kind of node to be created
             # @param defined [Bool] - kind of node to be created
@@ -87,9 +89,9 @@ module Krane
             # @param aggregable_by [String] - options for given node kind
             #
             # @return [nil]
-            def node_role(kind:, name:, version: nil, created_at: nil, defined: true, 
+            def node_role(kind:, name:, namespace: nil, version: nil, created_at: nil, defined: true,
                 is_default: false, is_composite: false, is_aggregable: false, aggregable_by: '')
-              label = make_label kind, name
+              label = label_for kind, name, namespace
 
               # build a hash attributes for the node automatically
               attrs = (local_variables - [:label, :attrs]).each_with_object({}) do |p, hsh|
@@ -139,11 +141,14 @@ module Krane
             #
             # @param kind [Symbol] - RBAC Subject kind (:User, :Group, :ServiceAccount)
             # @param name [String] - subject name
+            # @param namespace [String] - the subject's own namespace. Part of the node identity
+            #                             for :ServiceAccount; :User and :Group are not namespaced.
             #
             # @return [nil]
-            def node_subject kind:, name:
-              label = make_label kind, name
+            def node_subject kind:, name:, namespace: nil
+              label = label_for kind, name, namespace
               attrs = { name: name, kind: kind }
+              attrs[:namespace] = namespace if namespaced?(kind) && namespace.present?
 
               add_node :Subject, label, attrs
             end

--- a/lib/krane/rbac/graph/concerns/roles.rb
+++ b/lib/krane/rbac/graph/concerns/roles.rb
@@ -84,32 +84,31 @@ module Krane
 
               namespace = role_kind == :Role ? role['metadata']['namespace'] : Krane::Rbac::Graph::Builder::ALL_NAMESPACES_PLACEHOLDER
 
-              # caching role namespace scope
-              @role_ns_lookup[role_name] = namespace if role_kind == :Role 
+              # caching role namespace scope. A role name is only unique within a namespace,
+              # so this collects every namespace the name is defined in rather than overwriting.
+              @role_ns_lookup[role_name] << namespace if role_kind == :Role 
 
-              entry = {
-                role_kind: role_kind,
-                role_name: role_name
-              }
-              
+              entry = role_identity(role_kind, role_name, namespace)
+
               @defined_roles << entry # caching role as defined
               @default_roles << entry if is_default # cache default roles
 
               node :namespace, { name: namespace }
-              node :role, { 
-                kind:          role_kind, 
-                name:          role_name, 
-                is_default:    is_default, 
+              node :role, {
+                kind:          role_kind,
+                name:          role_name,
+                namespace:     namespace,
+                is_default:    is_default,
                 is_composite:  is_composite,
-                is_aggregable: is_aggregable, 
+                is_aggregable: is_aggregable,
                 aggregable_by: aggregable_by.join(', '),
                 version:       version,
-                created_at:    created_at 
+                created_at:    created_at
               }
-              edge :scope, { 
-                role_kind: role_kind, 
-                role_name: role_name, 
-                namespace: namespace 
+              edge :scope, {
+                role_kind: role_kind,
+                role_name: role_name,
+                namespace: namespace
               }
 
               return if role_info[:rules].blank?
@@ -120,7 +119,8 @@ module Krane
                 edge :grant, {
                   role_kind: role_kind,
                   role_name: role_name,
-                  rule:      rule
+                  rule:      rule,
+                  namespace: namespace
                 }
                 edge :security, { rule: rule }
               end

--- a/spec/factories/lib/krane/rbac/graph/concerns/role_node_attrs.rb
+++ b/spec/factories/lib/krane/rbac/graph/concerns/role_node_attrs.rb
@@ -20,6 +20,7 @@ FactoryBot.define do
     transient do
       kind          { :Role }
       name          { 'role-name' }
+      namespace     { 'some-namespace' }
       version       { '271831670' }
       created_at    { '2017-09-29T16:21:33Z' }
       defined       { true }
@@ -31,7 +32,8 @@ FactoryBot.define do
 
     trait :for_cluster_role do
       transient do
-        kind { :ClusterRole }
+        kind      { :ClusterRole }
+        namespace { Krane::Rbac::Graph::Builder::ALL_NAMESPACES_PLACEHOLDER }
       end
     end
 
@@ -43,9 +45,10 @@ FactoryBot.define do
  
     skip_create
     initialize_with do
-      { 
+      {
         kind:          kind,
         name:          name,
+        namespace:     namespace,
         version:       version,
         created_at:    created_at,
         defined:       defined,

--- a/spec/lib/krane/rbac/graph/concerns/bindings_spec.rb
+++ b/spec/lib/krane/rbac/graph/concerns/bindings_spec.rb
@@ -223,8 +223,8 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Bindings do
           allow(subject).to receive(:edge).and_call_original
         end
 
-        it 'sets a :RELATION edge between any two subjects' do          
-          expect(subject).to receive(:edge).with(:relation, { 
+        it 'sets a :RELATION edge between any two subjects' do
+          expect(subject).to receive(:edge).with(:relation, {
             a_subject_kind: binding[:subjects].first[:kind],
             a_subject_name: binding[:subjects].first[:name],
             b_subject_kind: binding[:subjects].last[:kind],
@@ -233,6 +233,41 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Bindings do
 
           # call
           subject.send(:setup_binding, binding_kind: binding_kind, binding: binding)
+        end
+
+      end
+
+      # ServiceAccounts are namespaced, so `default` in kube-system and `default`
+      # in an application namespace are separate principals with separate
+      # privileges. Subjects are identified by kind+name alone, and the
+      # `namespace` supplied on the binding subject is never read, so every
+      # same-named ServiceAccount in the cluster merges into one graph node.
+      context 'for ServiceAccount subjects sharing a name across different namespaces' do
+
+        let(:binding_kind) { :ClusterRoleBinding }
+
+        let(:binding) do
+          build(:binding, :for_cluster_role,
+            subjects: [
+              build(:subject, :service_account, name: 'default', namespace: 'kube-system'),
+              build(:subject, :service_account, name: 'default', namespace: 'myapp')
+            ])
+        end
+
+        before do
+          subject.send(:setup_binding, binding_kind: binding_kind, binding: binding)
+        end
+
+        it 'creates a distinct :Subject graph node for each namespace' do
+          subject_nodes = subject.instance_variable_get(:@node_buffer).select {|n| n[:kind] == :Subject}
+
+          expect(subject_nodes.map(&:label).uniq.size).to eq 2
+        end
+
+        it 'records the namespace on each :Subject node' do
+          subject_nodes = subject.instance_variable_get(:@node_buffer).select {|n| n[:kind] == :Subject}
+
+          expect(subject_nodes.map {|n| n.attrs[:namespace]}).to contain_exactly('kube-system', 'myapp')
         end
 
       end

--- a/spec/lib/krane/rbac/graph/concerns/bindings_spec.rb
+++ b/spec/lib/krane/rbac/graph/concerns/bindings_spec.rb
@@ -74,9 +74,10 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Bindings do
       end
 
       it 'create :Subject graph node for subject referenced in the binding' do
-        expect(subject).to receive(:node).with(:subject, { 
-          kind: binding[:subjects].first[:kind],
-          name: binding[:subjects].first[:name]
+        expect(subject).to receive(:node).with(:subject, {
+          kind:      binding[:subjects].first[:kind],
+          name:      binding[:subjects].first[:name],
+          namespace: binding[:subjects].first[:namespace]
         })
 
         # call
@@ -95,11 +96,13 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Bindings do
       end
 
       it 'create :ASSIGN edge between :Role and :Subject nodes' do
-        expect(subject).to receive(:edge).with(:assign, { 
-          role_kind: binding[:roleRef][:kind], 
-          role_name: binding[:roleRef][:name], 
-          subject_kind: binding[:subjects].first[:kind], 
-          subject_name: binding[:subjects].first[:name]
+        expect(subject).to receive(:edge).with(:assign, {
+          role_kind:         binding[:roleRef][:kind],
+          role_name:         binding[:roleRef][:name],
+          role_namespace:    binding[:metadata][:namespace],
+          subject_kind:      binding[:subjects].first[:kind],
+          subject_name:      binding[:subjects].first[:name],
+          subject_namespace: binding[:subjects].first[:namespace]
         })
 
         # call
@@ -107,10 +110,11 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Bindings do
       end
 
       it 'create :ACCESS edge between :Subject and :Namespace nodes' do
-        expect(subject).to receive(:edge).with(:access, { 
-          subject_kind: binding[:subjects].first[:kind], 
-          subject_name: binding[:subjects].first[:name],
-          namespace: binding[:metadata][:namespace]
+        expect(subject).to receive(:edge).with(:access, {
+          subject_kind:      binding[:subjects].first[:kind],
+          subject_name:      binding[:subjects].first[:name],
+          subject_namespace: binding[:subjects].first[:namespace],
+          namespace:         binding[:metadata][:namespace]
         })
 
         # call
@@ -124,8 +128,9 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Bindings do
         referenced_roles = subject.instance_variable_get(:@referenced_roles)
 
         expect(referenced_roles).to include(
-          role_kind:    binding[:roleRef][:kind], 
-          role_name:    binding[:roleRef][:name]
+          role_kind:      binding[:roleRef][:kind],
+          role_name:      binding[:roleRef][:name],
+          role_namespace: binding[:metadata][:namespace]
         )
       end
 
@@ -166,10 +171,11 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Bindings do
         end
 
         it 'creates missing :Role node with `disabled` flag set to true' do
-          expect(subject).to receive(:node).with(:role, { 
-            kind: binding[:roleRef][:kind],
-            name: binding[:roleRef][:name],
-            defined: false
+          expect(subject).to receive(:node).with(:role, {
+            kind:      binding[:roleRef][:kind],
+            name:      binding[:roleRef][:name],
+            namespace: binding[:metadata][:namespace],
+            defined:   false
           })
 
           # call
@@ -183,10 +189,11 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Bindings do
           undefined_roles = subject.instance_variable_get(:@undefined_roles)
 
           expect(undefined_roles).to include(
-            role_kind:    binding[:roleRef][:kind], 
-            role_name:    binding[:roleRef][:name], 
-            binding_kind: binding_kind, 
-            binding_name: binding[:metadata][:name]
+            role_kind:      binding[:roleRef][:kind],
+            role_name:      binding[:roleRef][:name],
+            role_namespace: binding[:metadata][:namespace],
+            binding_kind:   binding_kind,
+            binding_name:   binding[:metadata][:name]
           )
         end
 
@@ -225,10 +232,12 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Bindings do
 
         it 'sets a :RELATION edge between any two subjects' do
           expect(subject).to receive(:edge).with(:relation, {
-            a_subject_kind: binding[:subjects].first[:kind],
-            a_subject_name: binding[:subjects].first[:name],
-            b_subject_kind: binding[:subjects].last[:kind],
-            b_subject_name: binding[:subjects].last[:name]
+            a_subject_kind:      binding[:subjects].first[:kind],
+            a_subject_name:      binding[:subjects].first[:name],
+            a_subject_namespace: binding[:subjects].first[:namespace],
+            b_subject_kind:      binding[:subjects].last[:kind],
+            b_subject_name:      binding[:subjects].last[:name],
+            b_subject_namespace: binding[:subjects].last[:namespace]
           })
 
           # call

--- a/spec/lib/krane/rbac/graph/concerns/roles_spec.rb
+++ b/spec/lib/krane/rbac/graph/concerns/roles_spec.rb
@@ -105,12 +105,13 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Roles do
         end
 
         it 'creates :Role graph node' do
-          expect(subject).to receive(:node).with(:role, { 
-            kind:          role_kind, 
-            name:          role[:metadata][:name], 
-            is_default:    false, 
+          expect(subject).to receive(:node).with(:role, {
+            kind:          role_kind,
+            name:          role[:metadata][:name],
+            namespace:     role[:metadata][:namespace],
+            is_default:    false,
             is_composite:  false,
-            is_aggregable: false, 
+            is_aggregable: false,
             aggregable_by: '',
             version:       role[:metadata][:resourceVersion],
             created_at:    role[:metadata][:creationTimestamp]
@@ -132,10 +133,11 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Roles do
         end
 
         it 'creates :GRANT graph edge between :Role and :Rule nodes' do
-          expect(subject).to receive(:edge).with(:grant, { 
-            role_kind: role_kind, 
-            role_name: role[:metadata][:name], 
-            rule:      subject.process_resource_rule(role[:rules].first).first
+          expect(subject).to receive(:edge).with(:grant, {
+            role_kind: role_kind,
+            role_name: role[:metadata][:name],
+            rule:      subject.process_resource_rule(role[:rules].first).first,
+            namespace: role[:metadata][:namespace]
           })
         end
 
@@ -155,13 +157,16 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Roles do
         defined_roles  = subject.instance_variable_get(:@defined_roles)
         default_roles  = subject.instance_variable_get(:@default_roles)
 
+        # A role name is only unique within a namespace, so the lookup maps a name to the
+        # set of namespaces it is defined in.
         expect(role_ns_lookup).to include(
-          role[:metadata][:name] => role[:metadata][:namespace]
+          role[:metadata][:name] => Set[role[:metadata][:namespace]]
         )
 
         expect(defined_roles).to include(
-          role_kind: :Role,
-          role_name: role[:metadata][:name]
+          role_kind:      :Role,
+          role_name:      role[:metadata][:name],
+          role_namespace: role[:metadata][:namespace]
         )
 
         expect(default_roles).to be_empty
@@ -233,8 +238,9 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Roles do
 
           default_roles = subject.instance_variable_get(:@default_roles)
           expect(default_roles).to include(
-            role_kind: :Role,
-            role_name: role[:metadata][:name]
+            role_kind:      :Role,
+            role_name:      role[:metadata][:name],
+            role_namespace: role[:metadata][:namespace]
           )
         end
 
@@ -339,12 +345,13 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Roles do
           expect(declared).to eq declared.uniq
         end
 
-        it 'tracks the namespace of each Role separately' do
-          # @role_ns_lookup is keyed by role name alone, so team-a's entry is
-          # silently overwritten by team-b's.
+        it 'tracks every namespace the Role name is defined in' do
+          # @role_ns_lookup is keyed by role name, which is only unique within a namespace.
+          # Holding a single namespace per name meant team-a was silently overwritten by
+          # team-b, so the lookup holds the set of namespaces instead.
           role_ns_lookup = subject.instance_variable_get(:@role_ns_lookup)
 
-          expect(role_ns_lookup.values.uniq).to contain_exactly('team-a', 'team-b')
+          expect(role_ns_lookup.values.flat_map(&:to_a)).to contain_exactly('team-a', 'team-b')
         end
 
       end

--- a/spec/lib/krane/rbac/graph/concerns/roles_spec.rb
+++ b/spec/lib/krane/rbac/graph/concerns/roles_spec.rb
@@ -280,6 +280,75 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Roles do
 
       end
 
+      # Namespaced Roles are identified by kind+name alone, so two Roles sharing a
+      # name in different namespaces collapse into a single graph node and their
+      # access rules are merged. Role names are only unique within a namespace, so
+      # this is the common case in any multi-tenant cluster, not an edge case.
+      context 'with two namespaced Roles sharing a name across different namespaces' do
+
+        let(:privileged_role) do
+          build(:role,
+            name:             'developer',
+            namespace:        'team-a',
+            resource_version: '111',
+            rules:            build_list(:resource_rule, 1,
+                                api_groups:     ['*'],
+                                resources:      ['*'],
+                                resource_names: nil,
+                                verbs:          ['*']))
+        end
+
+        let(:restricted_role) do
+          build(:role,
+            name:             'developer',
+            namespace:        'team-b',
+            resource_version: '222',
+            rules:            build_list(:resource_rule, 1,
+                                api_groups:     [''],
+                                resources:      ['pods'],
+                                resource_names: nil,
+                                verbs:          ['get']))
+        end
+
+        before do
+          subject.send(:setup_role, role_kind: :Role, role: privileged_role)
+          subject.send(:setup_role, role_kind: :Role, role: restricted_role)
+        end
+
+        it 'creates a distinct :Role graph node for each namespace' do
+          role_nodes = subject.instance_variable_get(:@node_buffer).select {|n| n[:kind] == :Role}
+
+          expect(role_nodes.map(&:label).uniq.size).to eq 2
+        end
+
+        it 'does not merge the access rules of the two Roles onto one node' do
+          # Each Role grants exactly one rule, so each :Role label must appear
+          # exactly once as the source of a :GRANT edge. A shared label means
+          # team-b's Role also reaches the wildcard rule defined in team-a.
+          grant_sources = subject.instance_variable_get(:@edge_buffer)
+                                 .select {|e| e.relation == :GRANT}
+                                 .map(&:source_label)
+
+          expect(grant_sources.tally.values).to all(eq 1)
+        end
+
+        it 'does not bind the same graph variable twice in the CREATE statement' do
+          # openCypher forbids redeclaring a bound variable within a single CREATE.
+          declared = subject.send(:nodes).join(',').scan(/\((n\d+):Role/).flatten
+
+          expect(declared).to eq declared.uniq
+        end
+
+        it 'tracks the namespace of each Role separately' do
+          # @role_ns_lookup is keyed by role name alone, so team-a's entry is
+          # silently overwritten by team-b's.
+          role_ns_lookup = subject.instance_variable_get(:@role_ns_lookup)
+
+          expect(role_ns_lookup.values.uniq).to contain_exactly('team-a', 'team-b')
+        end
+
+      end
+
       context 'with cluster role with aggregationRule defined' do
 
         let(:role_kind) { :ClusterRole }


### PR DESCRIPTION
## Problem

Namespaced Roles and ServiceAccount subjects were identified by `kind` + `name` alone. A Role name is
only unique *within* a namespace, and ServiceAccounts are namespaced, so same-named objects in
different namespaces collapsed into a single graph node and their access rules merged.

This is the normal shape of a multi-tenant cluster (`developer`, `deployer`, `ci` per team namespace;
a `default` ServiceAccount in every namespace), not an edge case. `subject['namespace']` from the
binding was never read anywhere in the codebase.

The emitted Cypher declared the same variable twice in one `CREATE`:

```
(n3:Role {name:'developer', version:'111', ...}),   ← team-a
(n3:Role {name:'developer', version:'222', ...}),   ← team-b, SAME variable
(n3)-[:GRANT]->(n4),                                 ← team-a's wildcard rule
(n3)-[:GRANT]->(n7)                                  ← team-b's read-only rule
```

RedisGraph 2.6.1 does **not** reject this. It silently creates one node, keeps the *first*
declaration, and discards the second — verified directly:

```
> GRAPH.QUERY dup "CREATE (n3:Role {name:'developer', version:'111'}),
                          (n3:Role {name:'developer', version:'222'})"
Nodes created: 1          ← not 2, and no error
> GRAPH.QUERY dup "MATCH (r:Role) RETURN r.name, r.version"
developer, 111            ← team-b's Role is simply gone
```

So krane never failed on these clusters; it ran cleanly and reported the wrong thing.

## Impact — real report output

Fixture: `developer` in `team-a` (`*/*/*`) and in `team-b` (`get pods`); a `default` ServiceAccount in
each, bound to its own namespace's Role.

```diff
  [warning] subjects-with-rbac-management
      - ServiceAccount default (in team-a namespace)
-     - ServiceAccount default (in team-b namespace)     ← FALSE POSITIVE
      - User mallory (in * namespace)
```

`team-b`'s `default` ServiceAccount can only `get pods`. `master` reported it as able to **manage
RBAC**. Note the summary line was byte-identical either way (`warning=2, success=52`) — the corruption
lived only in item detail, so nothing count-based would have surfaced it.

The multi-matcher templates make this worse: the `ID(ro0) = ID(roN)` AND-join is evaluated on node
identity, so two *different* same-named Roles each satisfying one half of a two-part matcher would
together satisfy both — inventing a privilege-escalation path that does not exist.

## Approach

Labels were derived independently at **9 call sites** across `nodes.rb` and `edges.rb`. Threading a
namespace argument through some but not all of them would leave edges pointing at labels no node
declares — a failure that is silent in the generated Cypher. So identity is centralised instead:

- **`Builder#label_for`** + **`NAMESPACED_KINDS`** — the single place that decides what makes an
  entity distinct. `:Role` and `:ServiceAccount` are namespace-scoped; `:ClusterRole`, `:User` and
  `:Group` correctly are not.
- **`Builder#role_identity`** — the same rule for set membership (see below).
- A subject's **own** namespace is now distinct from the namespace it is **granted access to**. These
  were the same variable, but a ServiceAccount in one namespace can be bound into another.
- **`@role_ns_lookup`** holds a `Set` of namespaces per role name instead of a single value that was
  silently overwritten. A name defined in several namespaces falls back to the cluster-wide
  placeholder rather than guessing.

### A regression this caught, worth reviewing closely

Making node labels namespace-aware while leaving `@defined_roles` keyed on `kind`+`name` meant a Role
defined in `team-a` was treated as satisfying a binding referencing that name in `team-b`: no
missing-role node was created, but the edges used a namespace-qualified label, leaving a **dangling
reference** (`n6` referenced by two edges, declared by none). That converted a silent
wrong-attribution into a hard failure.

**All unit tests were green while this bug was live.** Only an end-to-end check of the emitted
graph caught it. Hence `role_identity`: node identity and set identity have to change together.

It also fixed a pre-existing **false negative**: such a binding is now correctly
reported by `missing-roles-in-bindings` instead of being silently suppressed, and `dangling-roles`
now distinguishes same-named Roles per namespace.

## Verification

- 6 tests written failing first (4 for Roles, 2 for ServiceAccounts), then greened. Full suite:
  **159 examples, 0 failures**.
- Executed end to end against **RedisGraph 2.6.1**: `master` vs this branch, identical fixture, full
  `krane report -o json`, findings diffed. The false positive above is real output.
- **No query regressed** — same rules fired, same statuses, 52 successes on both sides. The schema
  change silently killed nothing, which was the main risk.
- Four fixtures checked for graph invariants — same-named Roles across namespaces, same-named
  ServiceAccounts, a Role bound from a namespace it is not defined in, and aggregated ClusterRoles:
  **no duplicate node labels, no dangling edge references**, cluster-scoped kinds unaffected.
- Network view: 7 nodes → 9, with two distinct `Role: developer` and two `ServiceAccount: default`.

Worth noting:

- **Findings will move for existing users.** Mostly false positives disappearing, but splitting merged
  nodes can also surface true positives that were previously hidden. `missing-roles-in-bindings` is
  `:warning`, so `--ci` (which fails only on `:danger`) is unaffected — but `:danger` rules can change.
- **This is a graph schema change.** Anyone querying the graph directly — a documented feature — sees
  new `namespace` properties on `:Role`/`:Subject` nodes and separate nodes where there was one.
- **Validated against RedisGraph 2.6.1 only.** If the graph backend is replaced, this needs
  re-validating there.
