### PR TITLE
Unbreak the image build: drop npm audit fix and stop omitting dev deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,11 @@ RUN bundle config set without 'development test'
 RUN bundle install --jobs 20 --retry 5
 
 # build the dashboard elements
-RUN cd dashboard && npm install --omit=optional --omit=dev && npm audit fix && npm rebuild node-sass && npm install -g sass-migrator && sass-migrator division **/*.scss && rm -rf ./compiled && node_modules/.bin/gulp build
+# Do not add `npm audit fix` here: it rewrites the dependency tree at build time and exits
+# non-zero when advisories need --force, breaking the build on unchanged code.
+# Do not add `--omit=dev`: gulpfile.js imports nodemon at the top level, so gulp cannot load
+# without devDependencies.
+RUN cd dashboard && npm ci --omit=optional && npm install -g sass-migrator && sass-migrator division **/*.scss && rm -rf ./compiled && node_modules/.bin/gulp build
 
 ##############################################################
 # Stage: jekyll -- generate dashboard html files


### PR DESCRIPTION
## Why

`ci/circleci: build_only` is a required check and was failing on **every branch** — including PRs
touching only spec files — so nothing in the repo could merge, including all ~28 open PRs.

Two problems, the first masking the second:

1. **`npm audit fix` ran inside the build.** It rewrites the dependency tree at build time, so the
   same commit produced different images on different days, and it exits non-zero when advisories
   need `--force`. New `@babel/core` and `uuid` (via `vis-network`) advisories made it fail on
   unchanged code — which is why builds that passed in November failed on untouched commits.

2. **Removing it exposed a latent break.** `gulpfile.js:20` imports `nodemon` at the top level, but
   `nodemon` is the only `devDependency` and the build used `--omit=dev`. ESM evaluates imports on
   load, so `gulp build` failed with `ERR_MODULE_NOT_FOUND` even though only the `develop` task uses
   nodemon. `npm audit fix` had been re-resolving the tree and pulling it back in (`added 33
   packages`), so it was accidentally load-bearing. Dates from #448.

## What

Single `RUN` line in `Dockerfile`:

- Drop `npm audit fix` — dependency updates belong in `package-lock.json`, in a commit.
- Drop `--omit=dev` — this stage runs gulp, which is build tooling.
- `npm install` → `npm ci` — installs exactly what the lockfile specifies.
- Drop `npm rebuild node-sass` — `node-sass` is no longer a dependency.

Both removals are commented in place so they don't get reintroduced.

## Verified

- `docker build --platform linux/amd64` → exit 0, end to end including the jekyll stage.
- Image runs `bin/krane --version` (also the chart's liveness probe), with all 8 compiled pages
  present.
- `ci/circleci: build_only` **passes** on this PR.

## Note

The three advisories are now visible rather than papered over at build time, and still need fixing in
`package-lock.json` — `uuid` needs a breaking major bump. No overlap with #450.
