### PR TITLE
Show namespace in the tree and network views

### DIFF
--- a/lib/krane/rbac/graph/node.rb
+++ b/lib/krane/rbac/graph/node.rb
@@ -54,10 +54,17 @@ module Krane
           # Generate network graph nodes (excluding Psp, Rule nodes)
           k = attrs[:kind] || kind   # get :kind from node attributes, or node kind
           l = attrs[:name] || label  # get :name from node attributes, or node label
+          n = attrs[:namespace]      # namespace scoped entities only (:Role, :ServiceAccount)
           d = attrs[:is_default]     # :Role specific
           c = attrs[:is_composite]   # :Role specific
           a = attrs[:is_aggregable]  # :Role specific
           i = attrs[:aggregable_by]  # :Role specific
+
+          # Namespace scoped entities are distinct nodes per namespace, so the namespace has to
+          # appear in the label - without it two separate nodes render identically and the viewer
+          # cannot tell them apart. Cluster scoped entities carry the all-namespaces placeholder,
+          # which says nothing and is left out.
+          l = "#{l} (#{n})" if n.present? && n.to_s != Builder::ALL_NAMESPACES_PLACEHOLDER
 
           title = if (kind == :Role)
             ["#{k}: #{l}"].tap do |t|

--- a/lib/krane/visualisations/tree_view/builder.rb
+++ b/lib/krane/visualisations/tree_view/builder.rb
@@ -44,8 +44,9 @@ module Krane
           res = @graph.query(%Q(
             MATCH (ns:Namespace)<-[:ACCESS]-(s:Subject)-[:ASSIGN]->(r:Role)-[:GRANT]->(ru:Rule)
             RETURN ns.name as namespace_name,
-                   s.kind as subject_kind, 
+                   s.kind as subject_kind,
                    s.name as subject_name,
+                   s.namespace as subject_namespace,
                    r.kind as role_kind, 
                    r.name as role_name,
                    r.is_default as role_is_default,

--- a/lib/krane/visualisations/tree_view/element.rb
+++ b/lib/krane/visualisations/tree_view/element.rb
@@ -34,7 +34,7 @@ module Krane
           build_facet(facet) do
             add tag: :Namespace, text: namespace, resource_kind: :NAMESPACE
             add tag: :admits, text: subject_kind
-            add tag: subject_kind, text: subject_name, resource_kind: :ACTOR
+            add tag: subject_kind, text: actor, resource_kind: :ACTOR
             add tag: :to, text: rule_type
 
             if resource_related?
@@ -52,7 +52,7 @@ module Krane
         def subjects facet
           build_facet(facet) do
             add tag: :Actor, text: subject_kind
-            add tag: subject_kind, text: subject_name, resource_kind: :ACTOR
+            add tag: subject_kind, text: actor, resource_kind: :ACTOR
             add tag: :'in namespace', text: namespace, resource_kind: :NAMESPACE
             add tag: :'has access to', text: rule_type
 
@@ -84,7 +84,7 @@ module Krane
             add tag: :action, text: rule_verb
             add tag: :'in namespace', text: namespace, resource_kind: :NAMESPACE
             add tag: :to, text: subject_kind
-            add tag: subject_kind, text: subject_name, resource_kind: :ACTOR
+            add tag: subject_kind, text: actor, resource_kind: :ACTOR
           end
         end
 
@@ -103,7 +103,7 @@ module Krane
             add tag: :'granted to', text: role_kind
             add tag: [role_kind, default_role, aggregable_role, composite_role].compact, text: role_name, resource_kind: :ROLE
             add tag: :'with actor', text: subject_kind
-            add tag: subject_kind, text: subject_name, resource_kind: :ACTOR
+            add tag: subject_kind, text: actor, resource_kind: :ACTOR
             add tag: :'in namespace', text: namespace, resource_kind: :NAMESPACE
           end
         end
@@ -121,6 +121,17 @@ module Krane
         def namespace
           return ALL_NAMESPACES if namespace_name == '*'
           namespace_name
+        end
+
+        # Display name for a subject.
+        #
+        # ServiceAccounts are namespaced, so the namespace forms part of the subject's identity.
+        # Keying the tree on the name alone merges same-named ServiceAccounts from different
+        # namespaces into one entry showing the union of two separate principals' access.
+        # :User and :Group are not namespaced and are left undecorated.
+        def actor
+          return subject_name if subject_namespace.blank? || subject_namespace == 'NULL'
+          "#{subject_name} (#{subject_namespace})"
         end
 
         def resource_name

--- a/spec/lib/krane/rbac/graph/node_spec.rb
+++ b/spec/lib/krane/rbac/graph/node_spec.rb
@@ -184,6 +184,66 @@ RSpec.describe Krane::Rbac::Graph::Node do
 
     end
 
+    # Namespace-scoped entities are distinct graph nodes per namespace, so the network view
+    # must distinguish them - otherwise two separate nodes render with an identical label and
+    # the viewer cannot tell which is which.
+    context 'for a namespace scoped node' do
+
+      context 'for a ServiceAccount :Subject' do
+
+        subject do
+          build(:node, :subject, attrs: { kind: :ServiceAccount, name: 'default', namespace: 'team-a' })
+        end
+
+        it 'includes the namespace in the network label' do
+          expect(subject.to_network[:label]).to eq 'ServiceAccount: default (team-a)'
+        end
+
+        it 'includes the namespace in the network title' do
+          expect(subject.to_network[:title]).to include 'team-a'
+        end
+
+      end
+
+      context 'for a namespaced :Role' do
+
+        subject do
+          build(:node, :role, attrs: { kind: :Role, name: 'developer', namespace: 'team-b' })
+        end
+
+        it 'includes the namespace in the network label' do
+          expect(subject.to_network[:label]).to eq 'Role: developer (team-b)'
+        end
+
+      end
+
+      context 'for a cluster scoped :ClusterRole' do
+
+        subject do
+          build(:node, :role, attrs: {
+            kind: :ClusterRole, name: 'admin',
+            namespace: Krane::Rbac::Graph::Builder::ALL_NAMESPACES_PLACEHOLDER
+          })
+        end
+
+        it 'does not decorate the label with the all-namespaces placeholder' do
+          expect(subject.to_network[:label]).to eq 'ClusterRole: admin'
+        end
+
+      end
+
+      context 'for a :User subject, which is not namespaced' do
+
+        subject { build(:node, :subject, attrs: { kind: :User, name: 'alice' }) }
+
+        it 'leaves the label undecorated' do
+          expect(subject.to_network[:label]).to eq 'User: alice'
+        end
+
+      end
+
+    end
+
     context 'for :Namespace node kind' do
 
       subject { build(:node, :namespace) }

--- a/spec/lib/krane/visualisations/tree_view/element_spec.rb
+++ b/spec/lib/krane/visualisations/tree_view/element_spec.rb
@@ -1,0 +1,108 @@
+RSpec.describe Krane::Visualisations::TreeView::Element do
+
+  # Mirrors the columns returned by TreeView::Builder#query_graph
+  def record overrides = {}
+    {
+      namespace_name:      'team-a',
+      subject_kind:        'ServiceAccount',
+      subject_name:        'default',
+      subject_namespace:   'team-a',
+      role_kind:           'Role',
+      role_name:           'developer',
+      role_is_default:     'false',
+      role_is_composite:   'false',
+      role_is_aggregable:  'false',
+      rule_type:           'resource',
+      rule_api_group:      'core',
+      rule_resource:       'pods',
+      rule_resource_name:  'NULL',
+      rule_url:            'NULL',
+      rule_verb:           'get'
+    }.merge(overrides)
+  end
+
+  # TreeView::Builder seeds an infinitely nested Hash
+  def new_facets
+    Hash.new { |h, k| h[k] = Hash.new(&h.default_proc) }
+  end
+
+  def build_facets(*records, key:)
+    new_facets.tap do |facets|
+      records.each { |r| described_class.new(r).build(facets: facets, with_keys: [key]) }
+    end
+  end
+
+  describe '#subjects' do
+
+    # ServiceAccounts are namespaced, so `default` in team-a and `default` in team-b are separate
+    # principals. Keying the facet on subject name alone merges them into one tree entry, showing
+    # the union of two principals' access under a single node.
+    context 'for ServiceAccounts sharing a name across different namespaces' do
+
+      let(:facets) do
+        build_facets(
+          record(subject_namespace: 'team-a', namespace_name: 'team-a'),
+          record(subject_namespace: 'team-b', namespace_name: 'team-b'),
+          key: :subjects
+        )
+      end
+
+      # facet nesting: { {tag: :Actor, text: kind} => { {tag: kind, text: <actor>} => ... } }
+      let(:actors) { facets[:subjects].values.first.keys }
+
+      it 'creates a distinct tree entry per namespace' do
+        expect(actors.size).to eq 2
+      end
+
+      it 'labels each entry with its own namespace' do
+        expect(actors.map { |a| a[:text] }).to contain_exactly(
+          'default (team-a)', 'default (team-b)'
+        )
+      end
+
+    end
+
+    context 'for a subject kind which is not namespaced' do
+
+      let(:facets) do
+        build_facets(record(subject_kind: 'User', subject_name: 'alice', subject_namespace: 'NULL'), key: :subjects)
+      end
+
+      let(:actors) { facets[:subjects].values.first.keys }
+
+      it 'leaves the subject name undecorated' do
+        expect(actors.map { |a| a[:text] }).to eq ['alice']
+      end
+
+    end
+
+  end
+
+  describe '#namespaces' do
+
+    context 'for ServiceAccounts sharing a name across different namespaces' do
+
+      let(:facets) do
+        build_facets(
+          record(subject_namespace: 'team-a'),
+          record(subject_namespace: 'team-b'),
+          key: :namespaces
+        )
+      end
+
+      # namespaces facet nests Namespace -> admits -> subject_kind -> subject
+      let(:actors) do
+        facets[:namespaces].values.first.values.first.keys
+      end
+
+      it 'distinguishes the two subjects' do
+        expect(actors.map { |a| a[:text] }).to contain_exactly(
+          'default (team-a)', 'default (team-b)'
+        )
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
## Why

#509 made namespaced Roles and ServiceAccounts distinct graph nodes, but left both visualisations
unable to tell them apart — so the JSON report and the dashboard disagreed with each other.

- **Tree view:** `TreeView::Builder#query_graph` did not select the subject's namespace, and
  `TreeView::Element` keyed the subject facet on kind and name alone. Two `default` ServiceAccounts
  from different namespaces merged into one entry showing the union of two separate principals'
  access.
- **Network view:** `Node#to_network` built its label from kind and name, so the two
  now-correctly-distinct nodes both rendered as `ServiceAccount: default`.

## What

- `query_graph` returns `s.namespace`.
- `Element#actor` renders `default (team-a)` for namespaced subjects, leaving `:User` and `:Group`
  undecorated. Applied at all four places a subject appears as a facet — namespaces, subjects, roles,
  resources — since any one of them merging would reintroduce the problem.
- `Node#to_network` includes the namespace when present, omitting it for cluster scoped entities that
  carry the all-namespaces placeholder (which says nothing).

## Verified

Same fixture as #509 — `developer` in team-a and team-b, a `default` ServiceAccount in each — run
through `krane report --dir` against RedisGraph 2.6.1.

**Tree, Actors branch**

```diff
  User
      mallory
  ServiceAccount
-     default                    ← two principals merged into one entry
+     default (team-a)
+     default (team-b)
```

**Network node labels**

```diff
- Role: developer                ← two distinct nodes, identical labels
- Role: developer
+ Role: developer (team-a)
+ Role: developer (team-b)
- ServiceAccount: default
- ServiceAccount: default
+ ServiceAccount: default (team-a)
+ ServiceAccount: default (team-b)
```

Also confirmed directly against RedisGraph that `s.namespace` on a `:Subject` without that property
returns NULL (mapped to `nil`), not the string `'NULL'` — so `actor`'s `blank?` branch is the one that
fires for `:User`/`:Group`.

## Tests

The visualisation layer had **no specs at all** (26.9% and 31.0% coverage). Adds
`tree_view/element_spec.rb` and namespace cases in `node_spec`, written failing-first — 6 red, then
green. Two control cases (`:User` subject, `:ClusterRole`) pass unchanged, confirming the
non-namespaced path is untouched.

**168 examples, 0 failures.** Lib coverage 77.57% → **80.94%**.