### PR TITLE
Authenticate the Kubernetes version check

### DIFF
--- a/lib/krane/clients/kubernetes.rb
+++ b/lib/krane/clients/kubernetes.rb
@@ -47,21 +47,24 @@ module Krane
         end
       end
 
+      # Kubernetes server version as reported by the API server `/version` endpoint.
+      # Raises when the version could not be retrieved or parsed.
       memoize def version
-        url = URI("#{@api_endpoint}/version")
+        client = Kubeclient::Client.new(
+          @api_endpoint, 'v1',
+          auth_options: @auth_options,
+          ssl_options:  @ssl_options
+        )
 
-        http = Net::HTTP.new(url.host, url.port)
-        http.use_ssl = (url.scheme == "https")
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        # `get_headers` carries the bearer token (re-read from the token file when in-cluster)
+        # and `create_rest_client` applies the CA and client certificate options.
+        # Note: kubeclient suffixes the endpoint it was given with `/api`, so derive the
+        # `/version` path from the endpoint we were configured with instead.
+        version_path = URI.parse(@api_endpoint.to_s).path.chomp('/') + '/version'
+        response     = client.create_rest_client(version_path).get(client.get_headers)
+        info         = JSON.parse(response)
 
-        request = Net::HTTP::Get.new(url)
-        request["Content-Type"] = "application/json"
-        request["Authorization"] = "Bearer #{@auth_options[:bearer_token]}"
-
-        response = http.request(request)
-        j = JSON.parse(response.read_body)
-
-        "#{j['major']}.#{j['minor']}".to_f
+        Gem::Version.new("#{info['major']}.#{info['minor']}".gsub(/[^\d.]/, ''))
       end
 
       memoize def psp

--- a/lib/krane/rbac/ingest.rb
+++ b/lib/krane/rbac/ingest.rb
@@ -24,6 +24,9 @@ module Krane
 
       RBAC_CACHE_DIR = File.expand_path(File.join(File.dirname(__FILE__), '../../../', 'cache'))
 
+      # PodSecurityPolicy (policy/v1beta1) was removed from Kubernetes in 1.25
+      PSP_REMOVED_IN = Gem::Version.new('1.25')
+
       def initialize options
         @options    = options
         @cluster    = get_cluster_slug
@@ -61,7 +64,7 @@ module Krane
 
         graph = build_graph(@cache_path) do
           bootstrap_nodes
-          psp if k8s.version < 1.25
+          psp if psp_supported?(k8s)
           roles
           cluster_roles
           role_bindings
@@ -85,6 +88,17 @@ module Krane
         }
       end
 
+      # PodSecurityPolicies are only fetched and indexed for clusters that still serve them.
+      # When the cluster version cannot be determined we skip them, as querying the removed
+      # `policy/v1beta1` API on a modern cluster fails the whole report with a 404.
+      def psp_supported? k8s
+        k8s.version < PSP_REMOVED_IN
+      rescue StandardError => e
+        banner :warn, "Unable to determine Kubernetes version (#{e.message}). " \
+                      "Skipping PodSecurityPolicy, removed in Kubernetes #{PSP_REMOVED_IN}."
+        false
+      end
+
       def build_graph(path, &block)
         Docile.dsl_eval(Graph::Builder.new(path: path, options: @options), &block)
       end
@@ -96,7 +110,7 @@ module Krane
 
         FileUtils.mkdir_p @cache_path
 
-        File.write("#{@cache_path}/psp",                 k8s.psp.get_pod_security_policies(as: :raw))  if k8s.version < 1.25
+        File.write("#{@cache_path}/psp",                 k8s.psp.get_pod_security_policies(as: :raw))  if psp_supported?(k8s)
         File.write("#{@cache_path}/roles",               k8s.rbac.get_roles(as: :raw))
         File.write("#{@cache_path}/rolebindings",        k8s.rbac.get_role_bindings(as: :raw))
         File.write("#{@cache_path}/clusterroles",        k8s.rbac.get_cluster_roles(as: :raw))

--- a/spec/lib/krane/clients/kubernetes_spec.rb
+++ b/spec/lib/krane/clients/kubernetes_spec.rb
@@ -74,6 +74,45 @@ RSpec.describe Krane::Clients::Kubernetes do
 
   end
 
+  describe '#version' do
+
+    let(:options) { OpenStruct.new(incluster: true) } # --incluster
+
+    let(:rest_client) { double }
+    let(:headers)     { { Authorization: 'Bearer xxxxx' } }
+    let(:client)      { double(get_headers: headers) }
+
+    before do
+      allow(File).to receive(:exist?).with(described_class::CA_FILE_PATH) { true }
+      allow(Kubeclient::Client).to receive(:new) { client }
+      allow(client).to receive(:create_rest_client).with('/version') { rest_client }
+    end
+
+    it 'queries the /version endpoint with the authentication and ssl options of the cluster' do
+      expect(Kubeclient::Client).to receive(:new).with(
+        described_class::API_ENDPOINT, 'v1',
+        auth_options: { bearer_token_file: described_class::TOKEN_FILE_PATH },
+        ssl_options:  { ca_file: described_class::CA_FILE_PATH }
+      ) { client }
+      expect(rest_client).to receive(:get).with(headers) { '{"major":"1","minor":"32"}' }
+
+      expect(subject.version).to eq Gem::Version.new('1.32')
+    end
+
+    it 'strips non numeric characters from the reported version' do
+      allow(rest_client).to receive(:get) { '{"major":"1","minor":"32+"}' }
+
+      expect(subject.version).to eq Gem::Version.new('1.32')
+    end
+
+    it 'raises when the api server does not return a version' do
+      allow(rest_client).to receive(:get) { '{"kind":"Status","code":401,"message":"Unauthorized"}' }
+
+      expect { subject.version }.to raise_error(ArgumentError)
+    end
+
+  end
+
   describe '#psp' do
 
     let(:options) { OpenStruct.new(incluster: true) } # --incluster

--- a/spec/lib/krane/rbac/ingest_spec.rb
+++ b/spec/lib/krane/rbac/ingest_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe Krane::Rbac::Ingest do
         @instance.instance_variable_set(:@cache_path, dir)
 
         allow(Krane::Clients::Kubernetes).to receive(:new).with(options) { k8s_client }
-        allow(k8s_client).to receive(:version) { 1.23 }
+        allow(k8s_client).to receive(:version) { Gem::Version.new('1.23') }
       end
 
       it 'will build and index rbac graph, and return a results map' do
@@ -229,7 +229,7 @@ RSpec.describe Krane::Rbac::Ingest do
       context 'for k8s version < 1.25' do
 
         before do
-          allow(k8s_client).to receive(:version) { 1.23 }
+          allow(k8s_client).to receive(:version) { Gem::Version.new('1.23') }
           allow(k8s_client).to receive_message_chain(:psp, :get_pod_security_policies).with(as: :raw) { psps }
         end
 
@@ -250,10 +250,30 @@ RSpec.describe Krane::Rbac::Ingest do
       context 'for k8s version >= 1.25' do
 
         before do
-          allow(k8s_client).to receive(:version) { 1.25 }
+          allow(k8s_client).to receive(:version) { Gem::Version.new('1.32') }
         end
 
         it 'will call Kubernetes API and fetch RBAC objects excluding deprecated PSPs and cache them locally' do
+          expect(FileUtils).to receive(:mkdir_p).with(dir)
+          expect(File).to_not receive(:write).with("#{dir}/psp", psps)
+          expect(File).to receive(:write).with("#{dir}/roles", roles)
+          expect(File).to receive(:write).with("#{dir}/rolebindings", role_bindings)
+          expect(File).to receive(:write).with("#{dir}/clusterroles", cluster_roles)
+          expect(File).to receive(:write).with("#{dir}/clusterrolebindings", cluster_role_bindings)
+
+          @instance.send(:fetch_rbac)
+        end
+
+      end
+
+
+      context 'when the k8s version cannot be determined' do
+
+        before do
+          allow(k8s_client).to receive(:version).and_raise(StandardError, 'Unauthorized')
+        end
+
+        it 'will not query the removed PSP API and will fetch the remaining RBAC objects' do
           expect(FileUtils).to receive(:mkdir_p).with(dir)
           expect(File).to_not receive(:write).with("#{dir}/psp", psps)
           expect(File).to receive(:write).with("#{dir}/roles", roles)


### PR DESCRIPTION
Fixes #491.

## The problem

Krane skips PodSecurityPolicy on clusters at 1.25 and above, where `policy/v1beta1` no longer exists. That guard has been in place since #298, but the version check it relies on never authenticated.

`Clients::Kubernetes#version` asked the API server for `/version` over a hand-rolled `Net::HTTP` request that read the token from `auth_options[:bearer_token]`. In-cluster only `bearer_token_file` is ever set, so the request went out as an anonymous one with an empty token. The ssl options were dropped too, so client certificates were never presented either.

Clusters that serve `/version` anonymously answered anyway, which is why this went unnoticed. [EKS 1.32 restricts anonymous access to the health endpoints](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions-extended.html) and returns 401 for `/version`.

The failure was silent. A 401 body has no `major` or `minor`, so `"#{j['major']}.#{j['minor']}".to_f` produced `0.0`, which compares as older than 1.25, and Krane then queried the removed API:

```
error: HTTP status code 404, the server could not find the requested resource for GET https://kubernetes.default.svc/apis/policy/v1beta1.
```

The report never completed, so the dashboard had nothing to show.

## The change

The request now goes through Kubeclient, which sends the bearer token read from the token file and applies the CA and client certificate options.

Versions are compared as `Gem::Version` rather than as floats. As floats `1.9` sorts above `1.25`, so PSPs were skipped on clusters that still had them, and a future `1.100` would parse as `1.1`.

Determining the version can still fail, on a cluster that denies the call for some other reason. Rather than fall back to the removed API, which is what turned a version check into a broken report, an undeterminable version now skips PSPs and says so.

No chart changes are needed. `/version` is a non-resource URL covered by `system:public-info-viewer`, which is bound to `system:authenticated`, so the existing ServiceAccount can read it.

## Testing

- Full suite passes, 240 examples. New specs cover `#version` and the undeterminable-version path.
- Against a stub API server that returns 401 for anonymous `/version`, as EKS 1.32 does: before, the version parsed to `0.0` and Krane went on to query `policy/v1beta1`; after, the token is sent, the version reads as 1.32 and PSPs are skipped.
- End-to-end `krane report` against Kubernetes v1.36.1 completes, writes no `psp` cache file, and reports the PSP rule as not applicable.
