### PR TITLE
Point the chart and the gem at v0.1.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    krane (0.1.0)
+    krane (0.1.4)
       activesupport
       colorize
       commander

--- a/charts/krane/Chart.yaml
+++ b/charts/krane/Chart.yaml
@@ -3,7 +3,7 @@ name: krane
 description: A Helm chart for Krane
 type: application
 version: 0.1.4
-appVersion: "v0.1.3"
+appVersion: "v0.1.4"
 sources:
   - https://github.com/appvia/krane
 maintainers:

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module Krane
-  VERSION = "0.1.0"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
## Chart

`appVersion` was still `v0.1.3`. The deployment template resolves the image as `{{ .Values.image.tag | default .Chart.AppVersion }}`, so installing chart 0.1.4 pulled the previous image. `helm template` now renders:

```
image: "quay.io/appvia/krane:v0.1.4"
```

The chart `version` is deliberately left at 0.1.4 rather than bumped. Nothing has consumed that release yet, so it is corrected in place.

## Gem

`Krane::VERSION` had been left at `0.1.0` since the initial release, so `krane --version` and `gem build` both understated what was shipped, across every release since. It now tracks the tag. `Gemfile.lock` follows because the gem is resolved from the path.

## Testing

- Suite passes, 240 examples.
- `gem build krane.gemspec` produces `krane-0.1.4.gem`.
- `helm template krane charts/krane` renders the v0.1.4 image.
