### PR TITLE
Publish the release image under the tag it was built for

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,13 @@ jobs:
             skaffold_tag=$(cat build/${CIRCLE_SHA1}.json | jq -r '.builds[0].tag | split("@")[0]')
             skaffold_image=$(cat build/${CIRCLE_SHA1}.json | jq -r '.builds[0].imageName')
             docker buildx imagetools create -t quay.io/appvia/krane:latest ${skaffold_tag}
+            # Skaffold names the image after `git describe`, which picks arbitrarily
+            # between tags sharing a commit, so a release can end up published under
+            # the chart's `krane-x.y.z` tag instead. Publish the release tag we were
+            # actually built for.
+            if [ -n "${CIRCLE_TAG:-}" ]; then
+              docker buildx imagetools create -t ${skaffold_image}:${CIRCLE_TAG} ${skaffold_tag}
+            fi
       - persist_to_workspace:
           root: ~/project
           paths:

--- a/k8s/krane-deployment.yaml
+++ b/k8s/krane-deployment.yaml
@@ -16,7 +16,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    io.appvia.krane/version: v0.1.0
+    io.appvia.krane/version: v0.1.4
     io.appvia.krane.service: krane
   name: krane
 spec:
@@ -47,7 +47,7 @@ spec:
           value: ""
         - name: SLACK_CHANNEL
           value: ""
-        image: quay.io/appvia/krane
+        image: quay.io/appvia/krane:v0.1.4
         imagePullPolicy: "IfNotPresent"
         livenessProbe:
           exec:

--- a/k8s/redisgraph-deployment.yaml
+++ b/k8s/redisgraph-deployment.yaml
@@ -16,7 +16,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    io.appvia.krane/version: v0.1.0
+    io.appvia.krane/version: v0.1.4
     io.appvia.krane.service: redisgraph
   name: redisgraph
 spec:


### PR DESCRIPTION
Two follow-ups from the v0.1.4 release.

## The release image can be published under the wrong tag

Skaffold's tag policy is `gitCommit`, which names the image after `git describe`. When more than one tag points at a commit, describe picks between them arbitrarily.

v0.1.4 hit this. chart-releaser tags the chart at the merge commit, so both tags landed on `9dfbf08`:

```
$ git rev-parse krane-0.1.4 v0.1.4
9dfbf08...   9dfbf08...
$ git describe --tags 9dfbf08
krane-0.1.4
```

The release build therefore published to `quay.io/appvia/krane:krane-0.1.4`, leaving `:v0.1.4` on the previous build — which the chart's `appVersion` then pointed every install at. It was corrected by hand with `docker buildx imagetools create`.

A tag build now also publishes under `$CIRCLE_TAG`, the tag CI was actually triggered for, which cannot be confused with another tag on the same commit. It retags rather than rebuilds, so both architectures carry over with the digests that were tested, and it reuses `skaffold_image`, which was already read out of the build manifest and until now unused. Branch builds are unaffected, since `CIRCLE_TAG` is only set for tags.

## The raw manifests describe a release they are not

`k8s/` is the install path for anyone not using the chart. Both deployments still carried `io.appvia.krane/version: v0.1.0` — the label was never bumped after the initial release — and the krane container had no tag at all, so it resolved to `:latest` and drifted from whatever the label claimed.

Both now say `v0.1.4` and the container is pinned to that image. This needs bumping at each release, as the chart's `appVersion` does.

## Testing

- Suite passes, 240 examples.
- `.circleci/config.yml` parses, and the new branch was exercised both ways: with `CIRCLE_TAG=v0.1.4` it produces exactly the command that fixed the release by hand, and with it unset the step is skipped.
- `kubectl apply --dry-run=client -f k8s/` accepts all five manifests.
- `skaffold render --images quay.io/appvia/krane:local-test-123` still rewrites the pinned reference, so `skaffold dev` is unaffected.
