### PR TITLE
Sort the RBAC facets tree in Ruby, not in RedisGraph

### DIFF
--- a/lib/krane/visualisations/tree_view/builder.rb
+++ b/lib/krane/visualisations/tree_view/builder.rb
@@ -38,6 +38,11 @@ module Krane
 
         private
 
+        # Deliberately unordered. RedisGraph buffers the whole projection to sort
+        # it, and on a mid-sized cluster that sort costs an order of magnitude
+        # more memory than the rows themselves - enough to have the graph killed
+        # where it runs under a memory limit, which is how it is shipped. Order
+        # is a display concern and `sorted` applies it on the way out.
         def query_graph
           res = @graph.query(%Q(
             MATCH (ns:Namespace)<-[:ACCESS]-(s:Subject)-[:ASSIGN]->(r:Role)-[:GRANT]->(ru:Rule)
@@ -56,7 +61,6 @@ module Krane
                    ru.resource_name as rule_resource_name, 
                    ru.url as rule_url, 
                    ru.verb as rule_verb
-            ORDER BY namespace_name,subject_kind,subject_name,role_kind,role_name,rule_resource
           ))
 
           [res.columns, res.resultset]
@@ -84,25 +88,32 @@ module Krane
               {
                 facet: :namespaces,
                 text: "Namespaces", # name
-                nodes: @facets[:namespaces].collect {|k,v| prepare_node(:NAMESPACE, k, v)} # children
+                nodes: sorted(@facets[:namespaces]).collect {|k,v| prepare_node(:NAMESPACE, k, v)} # children
               },
               {
                 facet: :subjects,
                 text: "Actors", # name
-                nodes: @facets[:subjects].collect {|k,v| prepare_node(:ACTOR, k, v)} # children
+                nodes: sorted(@facets[:subjects]).collect {|k,v| prepare_node(:ACTOR, k, v)} # children
               },
               {
                 facet: :roles,
                 text: "Roles", # name
-                nodes: @facets[:roles].collect {|k,v| prepare_node(:ROLE, k, v)} # children
+                nodes: sorted(@facets[:roles]).collect {|k,v| prepare_node(:ROLE, k, v)} # children
               },
               {
                 facet: :resources,
                 text: "Resource Access", # name
-                nodes: @facets[:resources].collect {|k,v| prepare_node(:RESOURCE, k, v)} # children
+                nodes: sorted(@facets[:resources]).collect {|k,v| prepare_node(:RESOURCE, k, v)} # children
               },
             ]
           }
+        end
+
+        # Top level of a facet, in display order. Everything below it is sorted by
+        # `prepare_node`; this is the one level that isn't, because it is read
+        # straight off the facet hash where the order is however the rows arrived.
+        def sorted facet
+          facet.sort_by {|key, _| key[:text].to_s}
         end
 
         def prepare_node branch, key, elements, level=0

--- a/spec/lib/krane/visualisations/tree_view/builder_spec.rb
+++ b/spec/lib/krane/visualisations/tree_view/builder_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+describe Krane::Visualisations::TreeView::Builder do
+
+  # The columns TreeView::Builder#query_graph projects, in order.
+  def columns
+    %w[
+      namespace_name subject_kind subject_name subject_namespace
+      role_kind role_name role_is_default role_is_composite role_is_aggregable
+      rule_type rule_api_group rule_resource rule_resource_name rule_url rule_verb
+    ]
+  end
+
+  # One row as the graph returns it: values positionally matching the columns.
+  def row namespace:, subject: 'default', role: 'developer', resource: 'pods'
+    [
+      namespace, 'ServiceAccount', subject, namespace,
+      'Role', role, 'false', 'false', 'false',
+      'resource', 'core', resource, 'NULL', 'NULL', 'get'
+    ]
+  end
+
+  # Stands in for the RedisGraph client, handing back a fixed resultset.
+  def graph_returning *rows
+    double(query: double(columns: columns, resultset: rows))
+  end
+
+  # The tree, without going near the graph or the filesystem: Writer is covered
+  # separately, and the client is reached for in the constructor.
+  def tree_for *rows
+    allow(Krane::Clients::RedisGraph).to receive(:client).and_return(graph_returning(*rows))
+    described_class.new(OpenStruct.new(cluster: 'test', verbose: false)).send(:prepare_data)
+  end
+
+  def facet tree, text
+    tree[:nodes].find { |node| node[:text] == text }
+  end
+
+  describe '#prepare_data' do
+
+    # The query used to carry an ORDER BY purely so that the facet hash came out
+    # in display order. RedisGraph pays for that sort in memory, so ordering is
+    # applied here instead - which only holds if it does not depend on the order
+    # rows arrive in.
+    context 'when the graph returns rows out of order' do
+
+      let(:tree) do
+        tree_for(
+          row(namespace: 'team-c'),
+          row(namespace: 'team-a'),
+          row(namespace: 'team-b')
+        )
+      end
+
+      it 'sorts the top level of a facet by name' do
+        expect(facet(tree, 'Namespaces')[:nodes].map { |n| n[:text] }).to eq %w[team-a team-b team-c]
+      end
+
+      it 'sorts levels below the top by name' do
+        namespaces = tree_for(
+          row(namespace: 'team-a', resource: 'secrets'),
+          row(namespace: 'team-a', resource: 'configmaps')
+        )
+
+        resources = facet(namespaces, 'Namespaces')[:nodes]
+                      .first[:nodes].first[:nodes].first[:nodes].first[:nodes]
+
+        expect(resources.map { |n| n[:text] }).to eq ['[core] configmaps', '[core] secrets']
+      end
+    end
+
+    context 'for every facet' do
+
+      let(:tree) { tree_for(row(namespace: 'team-b'), row(namespace: 'team-a')) }
+
+      it 'names the root after the cluster' do
+        expect(tree[:text]).to eq 'test cluster'
+      end
+
+      it 'builds all four branches' do
+        expect(tree[:nodes].map { |n| n[:facet] }).to eq %i[namespaces subjects roles resources]
+      end
+
+      it 'fills each branch' do
+        expect(tree[:nodes].map { |n| n[:nodes].size }).to all(be > 0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Partly addresses #372 (RBAC facets / RBAC graph not displayed).

## What the issue was

The reporter was on 0.1.0, whose Jekyll dashboard loaded the whole facet tree and graph in one document. That part is gone: #519 replaced it with lazily-chunked tree data and a neighbourhood-at-a-time graph, and both views render fine at the cluster size described in the issue.

What is *not* fixed is upstream of the UI — the report can't finish building the facets on a memory-limited RedisGraph.

## The defect

`TreeView::Builder#query_graph` carried an `ORDER BY` purely so the facet hash came out in display order. RedisGraph buffers the entire projection to sort it, and that buffer dwarfs the rows it holds.

Measured against a synthetic cluster matching the issue (150 Roles, 300 RoleBindings, 250 ClusterRoles, 170 ClusterRoleBindings, 40 namespaces), instrumenting every query the report runs:

| | peak RedisGraph memory |
|---|---|
| tree view query, with `ORDER BY` | **1604 MB** |
| same query, without | **128 MB** |
| same query, `count(*)` only | 7 MB |
| resident graph after the report | 8.6 MB |

`charts/krane/templates/deployment.yaml` runs RedisGraph under `limits.memory: 200Mi`, so at that cluster size the graph is killed while the facets are being built and the RBAC tree has nothing to show.

## The fix

Ordering is a display concern, and every level below the top was already sorted in Ruby by `prepare_node`. Sorting the top level there too — the one level that read straight off the facet hash — makes the query's `ORDER BY` redundant.

## Verification

- Peak memory across the whole report: **1969 MB → 529 MB**; for the tree query alone **1604 MB → 335 MB**.
- Generated tree output is **byte for byte identical**, across all 10,380 files a report at that cluster size produces (`diff -rq` clean).
- New `builder_spec.rb` pins the guarantee that replaced the `ORDER BY`: top-level facet entries come out sorted whatever order rows arrive in. Reverting the sort fails it.
- Full suite green (245 examples). Dashboard smoke-tested against the regenerated data — tree paints in 799 ms, branches expand in ~430 ms, cross-chunk search works, no console errors.

## Still outstanding

The remaining 529 MB peak is one query: `Rbac::Ingest#index_rbac` issues the entire graph as a single `CREATE`. At this cluster size that statement is 697 KB and transiently costs ~520 MB to parse and apply. Batching it is not a small change — edges reference node labels bound in the same statement, so splitting means matching nodes back — so I've left it. Worth its own issue; it keeps the report above the shipped 200Mi limit on larger clusters.

Also worth noting separately: `tree/search.json` is 4.2 MB at this cluster size and is fetched eagerly on every tree load, and the report writes 351 MB over 10,380 chunk files in ~5 minutes because the facet tree is a materialised namespace x subject x role x rule cross-product.