### PR TITLE
Detect access granted to unauthenticated subjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,36 @@ Note: Example query above will select all Subjects with assigned Roles/ClusterRo
 RBAC risk rules are defined in the [Rules](config/rules.yaml) file. The structure of each rule is largely self-explanatory.
 Built-in set can be expanded / overridden by adding extra custom rules to the [Cutom Rules](config/custom-rules.yaml) file.
 
+#### Unauthenticated access
+
+Most built-in rules judge a subject by the permissions it holds. The `unauthenticated-subject-access` rule
+judges it by *who it is*: any binding to `system:anonymous` (the identity the API server assigns to requests
+carrying no credentials) or to the `system:unauthenticated` group is reported as a `danger`, whatever the
+bound role grants.
+
+Two things make this rule behave differently to the others, both tunable through its `custom_params`:
+
+- It does **not** skip Kubernetes' own default roles. Every other subject rule filters them out, but
+  `cluster-admin`, `admin`, `edit`, `view` and the `system:*` ClusterRoles are precisely what an accidental
+  anonymous binding tends to reference, and the most damaging when it does.
+- It excludes, via `baseline_role_names`, the anonymous access a cluster legitimately ships with, so that
+  anything reported is worth acting on: `system:public-info-viewer`, bound to `system:unauthenticated` to
+  serve `/healthz`, `/livez`, `/readyz` and `/version`; and `kubeadm:bootstrap-signer-clusterinfo`, bound to
+  `system:anonymous` to serve the `cluster-info` ConfigMap that `kubeadm join` discovery reads.
+
+To report that baseline access too, empty the list in [Custom Rules](config/custom-rules.yaml):
+
+```yaml
+rules:
+- id: unauthenticated-subject-access
+  custom_params:
+    baseline_role_names: []
+```
+
+The same mechanism widens the check — add `system:authenticated` to `unauthenticated_subject_names` to also
+report permissions available to every authenticated principal. Roles listed under `whitelist_role_names` in
+the [Whitelist](config/whitelist.yaml) are excluded as well, for cluster-specific exceptions.
+
 #### Risk Rule Macros
 
 Macros are "containers" for a set of common/shared attributes, and referenced by one or more risk rules. If you choose to use macro in a given risk rule you would need to reference it by name, e.g. `macro: <macro-name>`. Note that attributes defined in referenced `macro` will take precedence over the same attributes defined on the rule level.
@@ -319,14 +349,15 @@ Rule can contain any of the following attributes:
     ```
      Attributes and values follow [Kubernetes RBAC role specification](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-examples).
 
-- `custom_params` [Optional] List of custom key-value pairs to be evaluated and replaced in a rule `query` and `writer` representation.
+- `custom_params` [Optional] Map of custom key-value pairs to be evaluated and replaced in a rule `query` and `writer` representation.
   - Example:
     ```yaml
     custom_params:
-    - attrA: valueA
-    - attrB: valueB
+      attrA: valueA
+      attrB: valueB
+      attrC: ['valueC1', 'valueC2']
     ```
-    Template placeholders for the keys above `{{attrA}}` and `{{attrB}}` will be replaced with `valueA` and `valueB` respectively.
+    Template placeholders for the keys above `{{attrA}}`, `{{attrB}}` and `{{attrC}}` will be replaced with `valueA`, `valueB` and `["valueC1", "valueC2"]` respectively. A list value is rendered as a CypherQL list, so it can be used directly with an `IN` predicate.
 
 - `threshold`  [Optional] Numeric value. When definied this will become available as template placeholder `{{threshold}}` in the `writer` expression.
 - `macro`      [Optional] Reference to common parameters defined in a named macro.

--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -50,11 +50,11 @@ macros:
 #                      - resources: ['cronjobs']
 #                        verbs: ['update']
 
-# :custom_params   - List of custom key-value pairs to be replaced in resolved :query / :writer.
+# :custom_params   - Map of custom key-value pairs to be replaced in resolved :query / :writer.
 #                    Example: 
 #                      custom_params:
-#                      - attrA: valueA
-#                      - attrB: valueB
+#                        attrA: valueA
+#                        attrB: valueB
 
 #                    Templated placeholders for keys above `{{attrA}}` and `{{attrB}}` will be replaced with `valueA` and `valueB` respectively.
 
@@ -91,6 +91,44 @@ rules:
 #
 # ==== End Example Rule ====
 #
+
+- id: unauthenticated-subject-access
+  group_title: Subjects granting access to unauthenticated callers
+  severity: :danger
+  info: |
+    Access has been granted to an unauthenticated identity. `system:anonymous` is the identity the
+    API server assigns to requests that carry no credentials, and every such request is also a member
+    of the `system:unauthenticated` group. Any permission reachable through these subjects is available
+    to anyone who can reach the API server. Review the bindings below and remove them.
+  # Unlike the subject rules below this one deliberately does NOT filter on `is_default`, because the
+  # default ClusterRoles (cluster-admin, admin, edit, view, system:*) are exactly the ones an
+  # anonymous binding is most likely to reference, and are the most damaging when it does.
+  # :baseline_role_names excludes the anonymous access every cluster ships with, so that what is left
+  # is always actionable: `system:public-info-viewer` (bound to `system:unauthenticated` to serve
+  # /healthz, /livez, /readyz and /version) and `kubeadm:bootstrap-signer-clusterinfo` (bound to
+  # `system:anonymous` to serve the `cluster-info` ConfigMap that `kubeadm join` discovery reads).
+  # Empty this list to also report those; override either list via config/custom-rules.yaml.
+  custom_params:
+    unauthenticated_subject_names: ['system:anonymous', 'system:unauthenticated']
+    baseline_role_names: ['system:public-info-viewer', 'kubeadm:bootstrap-signer-clusterinfo']
+  query: |
+    MATCH
+      (ro:Role {defined: 'true'})<-[:ASSIGN]-(s:Subject)
+    WHERE
+      s.name IN {{unauthenticated_subject_names}}
+      AND NOT ro.name IN {{baseline_role_names}}
+      AND NOT ro.name IN {{whitelist_role_names}}
+    RETURN
+      s.kind as subject_kind,
+      s.name as subject_name,
+      ro.kind as role_kind,
+      ro.name as role_name
+    ORDER BY
+      subject_name,
+      role_kind,
+      role_name
+  writer: |
+    "#{result.subject_kind} #{name_of(result.subject_name)} is bound to #{result.role_kind} #{name_of(result.role_name)}"
 
 - id: subjects-with-privileged-psp-not-scoped-to-ns
   group_title: Subjects with privileged PSP access NOT scoped to a namespace (N/A for K8s version >= 1.25)

--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -96,9 +96,9 @@ rules:
   group_title: Subjects granting access to unauthenticated callers
   severity: :danger
   info: |
-    Access has been granted to an unauthenticated identity. `system:anonymous` is the identity the
+    Access has been granted to an unauthenticated identity. system:anonymous is the identity the
     API server assigns to requests that carry no credentials, and every such request is also a member
-    of the `system:unauthenticated` group. Any permission reachable through these subjects is available
+    of the system:unauthenticated group. Any permission reachable through these subjects is available
     to anyone who can reach the API server. Review the bindings below and remove them.
   # Unlike the subject rules below this one deliberately does NOT filter on `is_default`, because the
   # default ClusterRoles (cluster-admin, admin, edit, view, system:*) are exactly the ones an

--- a/spec/config/rules_spec.rb
+++ b/spec/config/rules_spec.rb
@@ -1,0 +1,104 @@
+# Guards the rules krane actually ships, as opposed to resolver_spec.rb which drives the
+# resolver with synthetic rules from a factory. Nothing else in the suite reads
+# config/rules.yaml, so a rule can be edited into a shape that raises, or that silently
+# stops matching, without a single example failing.
+
+# Writers are Ruby, evaluated inside the report builder so they can reach the helpers it
+# carries. This stands in for that.
+class ShippedWriterContext
+  include Krane::Helpers
+
+  def evaluate writer, result # rubocop:disable Lint/UnusedMethodArgument -- the writer reads it
+    eval writer
+  end
+end
+
+RSpec.describe 'the shipped risk rules' do
+
+  let(:resolved) do
+    Krane::Report::RiskRule::Resolver.new(
+      cluster:   :default,
+      risk:      Krane::Config::Risk.new,
+      whitelist: Krane::Config::Whitelist.new
+    ).risk_rules
+  end
+
+  def rule id
+    resolved.find { |item| item[:id] == id }
+  end
+
+  it 'resolves every enabled rule' do
+    expect { resolved }.not_to raise_exception
+    expect(resolved).not_to be_empty
+  end
+
+  it 'leaves no placeholder unsubstituted in a writer' do
+    unsubstituted = resolved.each_with_object({}) do |item, hsh|
+      found = item[:writer].to_s.scan(/{{.*?}}/)
+      hsh[item[:id]] = found if found.any?
+    end
+
+    expect(unsubstituted).to be_empty
+  end
+
+  # Queries cannot be checked the same way: the whitelist step rewrites every {{...}} it does
+  # not recognise to [""], so a misspelt or undefined placeholder resolves to an empty list and
+  # silently widens the query rather than leaving a trace. Catch it at the source instead - each
+  # placeholder a rule writes must be one the resolver has a value for.
+  it 'only references placeholders the resolver can resolve' do
+    unresolvable = Krane::Config::Risk.new.rules.each_with_object({}) do |rule, hsh|
+      available = ['threshold'] + rule[:custom_params].to_h.keys.map(&:to_s)
+
+      found = [rule[:query], rule[:writer]].compact.flat_map { |str| str.scan(/{{(.*?)}}/).flatten }
+      # Whitelist keys are defined by the operator, so any of them may legitimately be absent.
+      found = found.reject { |name| name.start_with?('whitelist_') || available.include?(name) }
+
+      hsh[rule[:id]] = found if found.any?
+    end
+
+    expect(unresolvable).to be_empty
+  end
+
+  describe 'unauthenticated-subject-access' do
+
+    subject { rule('unauthenticated-subject-access') }
+
+    it 'is enabled and reports as a danger' do
+      expect(subject).not_to be_nil
+      expect(subject.disabled?).to be false
+      expect(subject[:severity]).to eq :danger
+    end
+
+    it 'matches both identities the API server gives an uncredentialed request' do
+      expect(subject[:query]).to include %q(s.name IN ["system:anonymous", "system:unauthenticated"])
+    end
+
+    # The crux of issue #339. Every other subject rule filters on `is_default: 'false'`, which
+    # is why binding cluster-admin to system:anonymous used to report nothing at all. Adding
+    # that filter here for consistency would silently reintroduce the bug, so pin its absence.
+    it 'does not exclude Kubernetes default roles' do
+      expect(subject[:query]).not_to include 'is_default'
+    end
+
+    it 'excludes the anonymous access a cluster legitimately ships with' do
+      expect(subject[:query]).to include(
+        %q(NOT ro.name IN ["system:public-info-viewer", "kubeadm:bootstrap-signer-clusterinfo"])
+      )
+    end
+
+    it 'writes a finding naming the subject and the role it is bound to' do
+      result = OpenStruct.new(
+        subject_kind: 'User',
+        subject_name: 'system:anonymous',
+        role_kind:    'ClusterRole',
+        role_name:    'cluster-admin'
+      )
+
+      expect(ShippedWriterContext.new.evaluate(subject[:writer], result)).to eq(
+        'User `system:anonymous` is bound to ClusterRole `cluster-admin`'
+      )
+    end
+
+  end
+
+end

--- a/spec/config/rules_spec.rb
+++ b/spec/config/rules_spec.rb
@@ -59,6 +59,15 @@ RSpec.describe 'the shipped risk rules' do
     expect(unresolvable).to be_empty
   end
 
+  # A finding's items are marker-rendered, so `name_of(...)` becomes bold in the dashboard. Its
+  # `info` is not - FindingCard.vue interpolates it as plain text - so a backtick written there
+  # reaches the user as a literal character.
+  it 'marks no names in rule info text' do
+    marked = resolved.select { |item| item[:info].to_s.include?('`') }.map { |item| item[:id] }
+
+    expect(marked).to be_empty
+  end
+
   describe 'unauthenticated-subject-access' do
 
     subject { rule('unauthenticated-subject-access') }


### PR DESCRIPTION
Closes #339.

## The gap

Every subject-oriented risk rule judges a subject by the permissions its roles grant, never by *who the subject is*. So a binding to `system:anonymous` was reported only if the bound role happened to trip one of those rules — and never at all when it referenced a default role, since all of them filter on `is_default: 'false'`.

`is_default` comes from the `kubernetes.io/bootstrapping: rbac-defaults` label, which covers `cluster-admin`, `admin`, `edit`, `view` and every `system:*` ClusterRole. Which means:

```
kubectl create clusterrolebinding anon --clusterrole=cluster-admin --user=system:anonymous
```

full cluster compromise by unauthenticated callers - produced **no finding whatsoever**. The binding was ingested fine; the rules simply had no way to see it.

## The rule

`unauthenticated-subject-access` reports any binding to `system:anonymous` or the `system:unauthenticated` group as `:danger`, whatever the bound role grants. Two deliberate deviations from the surrounding rules:

**No `is_default` filter.** The default roles are precisely what an accidental anonymous binding tends to reference, and the most damaging when it does. Commented in place, since it otherwise reads as an oversight. See the distribution survey below for a misconfiguration that exists in the wild and that an `is_default` filter would hide completely.

**Baseline exclusions via `custom_params.baseline_role_names`,** so that anything reported is actionable:

- `system:public-info-viewer` — bound to `system:unauthenticated` in every cluster to serve `/healthz`, `/livez`, `/readyz`, `/version`.
- `kubeadm:bootstrap-signer-clusterinfo` — bound to `system:anonymous` in every kubeadm-provisioned cluster to serve the `cluster-info` ConfigMap that `kubeadm join` discovery reads.

I only found the second by running the report end-to-end rather than reasoning about it. Without both, the rule fires `:danger` on a stock cluster and gets ignored. They live in `custom_params` rather than the query so users can empty the list for a strict posture, or add `system:authenticated` to `unauthenticated_subject_names` to widen the check. `{{whitelist_role_names}}` is honoured for cluster-specific exceptions.

## Verification

Real `bin/krane report` runs against a live FalkorDB, using both cached clusters in the repo:

| Case | Result |
|---|---|
| `system:anonymous` to `cluster-admin` (the reported scenario) | `danger`, correct finding |
| `system:unauthenticated` group to `view` | `danger`, correct finding |
| `cache/docker-desktop` unmodified | `success`, no items |
| `cache/default` unmodified | `success`, no items |
| `baseline_role_names: []` override | surfaces exactly the two baseline bindings |

The override case is the load-bearing one: it shows the exclusions are doing real work rather than the rule never matching. It also exercises the namespaced `RoleBinding` path, since `kubeadm:bootstrap-signer-clusterinfo` is a `Role`, not a `ClusterRole`.

## Baseline anonymous access

Before Kubernetes 1.14, `system:unauthenticated` was bound to `system:discovery` and `system:basic-user`. AWS documents that **cluster upgrades do not revoke these**, so a long-lived EKS or GKE cluster can still carry them on a current version. This rule reports them, and that is the correct outcome - AWS's own remediation is to strip `system:unauthenticated` from every binding except `system:public-info-viewer`.

## Test coverage

Nothing in the suite read `config/rules.yaml`, so this rule would otherwise ship with no regression protection -`resolver_spec` drives the resolver with factory rules, which exercises the mechanism but never the rules krane actually ships. `spec/config/rules_spec.rb` resolves the real set and pins the behaviour this rule argues for, in particular the *absence* of an `is_default` filter: adding one back for consistency with the neighbouring rules is exactly what reintroduces #339.

## Notes

**custom_params** was documented in both the README and `rules.yaml` as a YAML list of single-key hashes, but `Resolver#custom_params` has always iterated it as a map, so the documented form silently does nothing. This rule depends on that mechanism, so the docs are corrected rather than left contradicting a shipped rule.

**Output omits the namespace.** A `ClusterRole` is not namespace-scoped in the graph (`NAMESPACED_KINDS = [:Role, :ServiceAccount]`), so it accumulates `SCOPE` edges to every namespace any binding referenced it from — joining through those would attribute unrelated bindings' namespaces to the anonymous one. Reporting subject plus role only, matching `undefined_role_subjects`. Scope stays visible in the tree view.

**Filters `defined: 'true'`.** A binding to a non-existent role grants nothing today, but goes live the moment that role is created. Excluded for consistency with the other subject rules, since `subjects-with-non-existing-roles` already catches dangling bindings. Flagging latent anonymous bindings here too is a one-line change if preferred.
