### PR TITLE
Classify cloud provider RBAC as default roles

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    krane (0.1.5)
+    krane (0.1.6)
       activesupport
       colorize
       commander

--- a/README.md
+++ b/README.md
@@ -280,6 +280,33 @@ Note: Example query above will select all Subjects with assigned Roles/ClusterRo
 RBAC risk rules are defined in the [Rules](config/rules.yaml) file. The structure of each rule is largely self-explanatory.
 Built-in set can be expanded / overridden by adding extra custom rules to the [Cutom Rules](config/custom-rules.yaml) file.
 
+#### Default and vendor managed roles
+
+Most rules skip roles the cluster operator did not author, because a finding against a role nobody can edit
+is noise rather than a risk. That covers the roles Kubernetes bootstraps itself, labelled
+`kubernetes.io/bootstrapping: rbac-defaults`, and the RBAC a managed control plane installs and reconciles on
+your behalf — EKS, GKE, AKS and OpenShift all ship their own, and none of it carries the bootstrapping label.
+
+Vendor managed roles are recognised by the markers their provider stamps on the RBAC it owns, rather than by
+an enumeration of role names that would go stale with each provider release. A role qualifies when it carries
+one of these labels:
+
+| Label | Provider |
+|---|---|
+| `eks.amazonaws.com/component` | EKS |
+| `addonmanager.kubernetes.io/mode` | GKE, AKS |
+| `kubernetes.azure.com/managedby` | AKS |
+
+or when its name begins with a prefix the provider has reserved: `eks:`, `aws-node` (EKS); `gce:`,
+`system:gcp-`, `system:gke-` (GKE); `aks-`, `system:azure-` (AKS); `openshift-`, `system:openshift:`
+(OpenShift).
+
+To audit vendor RBAC as well, set `TREAT_VENDOR_MANAGED_ROLES_AS_DEFAULT=false` — vendor roles are then judged
+like any other, while Kubernetes' own defaults stay excluded. Setting
+`RISK_RULE_QUERY_EXCLUDE_DEFAULT_ROLES=false` goes further and brings both back into the role oriented rules.
+In the other direction, individual roles can be exempted by name through `whitelist_role_names` in the
+[Whitelist](config/whitelist.yaml).
+
 #### Unauthenticated access
 
 Most built-in rules judge a subject by the permissions it holds. The `unauthenticated-subject-access` rule

--- a/README.md
+++ b/README.md
@@ -302,7 +302,8 @@ or when its name begins with a prefix the provider has reserved: `eks:`, `aws-no
 (OpenShift).
 
 To audit vendor RBAC as well, set `TREAT_VENDOR_MANAGED_ROLES_AS_DEFAULT=false` — vendor roles are then judged
-like any other, while Kubernetes' own defaults stay excluded. Setting
+like any other, while Kubernetes' own defaults stay excluded. The Helm chart exposes this as
+`params.treatVendorManagedRolesAsDefault`. Setting
 `RISK_RULE_QUERY_EXCLUDE_DEFAULT_ROLES=false` goes further and brings both back into the role oriented rules.
 In the other direction, individual roles can be exempted by name through `whitelist_role_names` in the
 [Whitelist](config/whitelist.yaml).
@@ -512,6 +513,7 @@ You may control certain aspects of in-cluster execution with the following envir
 
 * `KRANE_REPORT_INTERVAL` - Defines interval in seconds for RBAC static analysis report run. Default: `300` (in seconds, i.e. 5 minutes).
 * `KRANE_REPORT_OUTPUT` - Defines RBAC risk report output format. Possible values `:json`, `:yaml`, `:none`. Default: `:json`.
+* `TREAT_VENDOR_MANAGED_ROLES_AS_DEFAULT` - Whether RBAC installed by a managed control plane is skipped by the risk rules, along with the Kubernetes defaults. See [Default and vendor managed roles](#default-and-vendor-managed-roles). Default: `true`.
 
 ### Local or Remote K8s Cluster
 

--- a/charts/krane/Chart.yaml
+++ b/charts/krane/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: krane
 description: A Helm chart for Krane
 type: application
-version: 0.1.5
-appVersion: "v0.1.5"
+version: 0.1.6
+appVersion: "v0.1.6"
 sources:
   - https://github.com/appvia/krane
 maintainers:

--- a/charts/krane/templates/deployment.yaml
+++ b/charts/krane/templates/deployment.yaml
@@ -111,6 +111,8 @@ spec:
             value: "{{ .Values.params.slackWebhookURL }}"
           - name: SLACK_CHANNEL
             value: "{{ .Values.params.slackChannel }}"
+          - name: TREAT_VENDOR_MANAGED_ROLES_AS_DEFAULT
+            value: "{{ .Values.params.treatVendorManagedRolesAsDefault }}"
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/krane/values.yaml
+++ b/charts/krane/values.yaml
@@ -14,6 +14,11 @@ params:
   falkorDBHost: falkordb
   slackWebhookURL: ""
   slackChannel: ""
+  # RBAC installed and reconciled by a managed control plane - EKS, GKE, AKS,
+  # OpenShift - is classified alongside the roles Kubernetes bootstraps, and so
+  # skipped by the risk rules that already exclude those. Set to false to have it
+  # judged like operator authored RBAC instead.
+  treatVendorManagedRolesAsDefault: true
 
 imagePullSecrets: []
 nameOverride: ""

--- a/k8s/falkordb-deployment.yaml
+++ b/k8s/falkordb-deployment.yaml
@@ -16,7 +16,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    io.appvia.krane/version: v0.1.5
+    io.appvia.krane/version: v0.1.6
     io.appvia.krane.service: falkordb
   name: falkordb
 spec:

--- a/k8s/krane-deployment.yaml
+++ b/k8s/krane-deployment.yaml
@@ -16,7 +16,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    io.appvia.krane/version: v0.1.5
+    io.appvia.krane/version: v0.1.6
     io.appvia.krane.service: krane
   name: krane
 spec:
@@ -47,7 +47,7 @@ spec:
           value: ""
         - name: SLACK_CHANNEL
           value: ""
-        image: quay.io/appvia/krane:v0.1.5
+        image: quay.io/appvia/krane:v0.1.6
         imagePullPolicy: "IfNotPresent"
         livenessProbe:
           exec:

--- a/lib/krane/rbac/graph/concerns/roles.rb
+++ b/lib/krane/rbac/graph/concerns/roles.rb
@@ -23,6 +23,37 @@ module Krane
         module Roles
           extend ActiveSupport::Concern
 
+          # Cloud providers install their own RBAC alongside the Kubernetes defaults. Those roles are
+          # no more actionable to a cluster operator than the bootstrapped ones - they are reconciled
+          # by the managed control plane and cannot be edited - but they carry no
+          # `kubernetes.io/bootstrapping` label, so without this they surface in every risk rule as
+          # noise the operator can do nothing about.
+          #
+          # Detection is marker based rather than an enumeration of role names, which would go stale
+          # with every provider release. A role counts as vendor managed when it either carries a
+          # label the provider stamps on the RBAC it owns, or its name uses a prefix the provider has
+          # reserved for itself.
+          VENDOR_MANAGED_ROLE_LABELS = [
+            'eks.amazonaws.com/component',     # EKS
+            'addonmanager.kubernetes.io/mode', # GKE and AKS addon manager
+            'kubernetes.azure.com/managedby'   # AKS
+          ].freeze
+
+          VENDOR_MANAGED_ROLE_NAME_PREFIXES = [
+            'eks:',              # EKS
+            'aws-node',          # EKS VPC CNI
+            'gce:',              # GKE
+            'system:gcp-',       # GKE
+            'system:gke-',       # GKE
+            'aks-',              # AKS
+            'system:azure-',     # AKS
+            'openshift-',        # OpenShift
+            'system:openshift:'  # OpenShift
+          ].freeze
+
+          # Set to false to have vendor managed roles evaluated like any other role.
+          TREAT_VENDOR_MANAGED_ROLES_AS_DEFAULT = true
+
           included do
 
             # Iterates through Roles and processes them
@@ -137,7 +168,7 @@ module Krane
                 role_name:      role['metadata']['name'],
                 version:        role['metadata']['resourceVersion'],
                 created_at:     role['metadata']['creationTimestamp'],
-                is_default:     role['metadata'].try(:[], 'labels').try(:[], 'kubernetes.io/bootstrapping') == 'rbac-defaults' || false,
+                is_default:     default_role?(role),
                 is_composite:   role.key?('aggregationRule'),
                 aggregable_by:  role['metadata'].key?('labels') && role['metadata']['labels'].collect do |k, v|
                                   k =~ /rbac.authorization.k8s.io\/aggregate-to-(.*)/ && v == 'true' ? $1 : nil
@@ -146,6 +177,47 @@ module Krane
               }.tap do |h|
                 h[:is_aggregable] = !h[:aggregable_by].empty?
               end
+            end
+
+            # Tells whether a role is supplied by the platform rather than by the cluster operator.
+            # That covers the roles Kubernetes bootstraps as well as the ones a managed control
+            # plane installs and reconciles on the operator's behalf.
+            #
+            # @param role [Hash] - raw Role/ClusterRole object
+            #
+            # @return [Bool]
+            def default_role? role
+              bootstrapped_role?(role) || vendor_managed_role?(role)
+            end
+
+            # Tells whether a role is one of the Kubernetes RBAC defaults
+            #
+            # @param role [Hash] - raw Role/ClusterRole object
+            #
+            # @return [Bool]
+            def bootstrapped_role? role
+              role['metadata'].try(:[], 'labels').try(:[], 'kubernetes.io/bootstrapping') == 'rbac-defaults'
+            end
+
+            # Tells whether a role is installed and reconciled by a cloud provider
+            #
+            # @param role [Hash] - raw Role/ClusterRole object
+            #
+            # @return [Bool]
+            def vendor_managed_role? role
+              return false unless treat_vendor_managed_roles_as_default?
+
+              labels = role['metadata'].try(:[], 'labels') || {}
+              name   = role['metadata']['name'].to_s
+
+              VENDOR_MANAGED_ROLE_LABELS.any? {|label| labels.key?(label) } ||
+                VENDOR_MANAGED_ROLE_NAME_PREFIXES.any? {|prefix| name.start_with?(prefix) }
+            end
+
+            def treat_vendor_managed_roles_as_default?
+              ENV.fetch(
+                'TREAT_VENDOR_MANAGED_ROLES_AS_DEFAULT', TREAT_VENDOR_MANAGED_ROLES_AS_DEFAULT
+              ).to_s == 'true'
             end
 
             # Caches aggregable roles

--- a/lib/krane/rbac/graph/node.rb
+++ b/lib/krane/rbac/graph/node.rb
@@ -68,7 +68,7 @@ module Krane
 
           title = if (kind == :Role)
             ["#{k}: #{l}"].tap do |t|
-              t << "- Default k8s role" if d
+              t << "- Default role (Kubernetes or cloud provider managed)" if d
               t << "- Aggregates rules defined in other cluster roles" if c
               t << "- Can be aggregated by cluster roles: #{i}" if a
             end.join("\n")

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module Krane
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/spec/factories/lib/krane/rbac/graph/concerns/role.rb
+++ b/spec/factories/lib/krane/rbac/graph/concerns/role.rb
@@ -72,6 +72,22 @@ FactoryBot.define do
       end
     end
 
+    trait :vendor_managed_by_label do
+      transient do
+        labels do
+          {
+            "eks.amazonaws.com/component": "addon-manager"
+          }
+        end
+      end
+    end
+
+    trait :vendor_managed_by_name do
+      transient do
+        name { 'eks:addon-manager' }
+      end
+    end
+
     skip_create
     initialize_with do
       {

--- a/spec/lib/krane/rbac/graph/concerns/roles_spec.rb
+++ b/spec/lib/krane/rbac/graph/concerns/roles_spec.rb
@@ -385,6 +385,55 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Roles do
 
     end
 
+    describe '#extract_role_attrs' do
+
+      # Cloud providers ship their own RBAC, which the operator can neither edit nor remove. Left
+      # unmarked it is evaluated like operator authored RBAC and fills the report with findings
+      # nothing can be done about, so it is classified alongside the Kubernetes defaults.
+      describe 'is_default' do
+
+        def is_default_for role
+          subject.send(:extract_role_attrs, role: role)[:is_default]
+        end
+
+        it 'is true for a role bootstrapped by Kubernetes' do
+          expect(is_default_for build(:cluster_role, :default)).to eq true
+        end
+
+        it 'is true for a role labelled as owned by a cloud provider' do
+          expect(is_default_for build(:cluster_role, :vendor_managed_by_label)).to eq true
+        end
+
+        it 'is true for a role named under a prefix a cloud provider reserves' do
+          expect(is_default_for build(:cluster_role, :vendor_managed_by_name)).to eq true
+        end
+
+        it 'is false for an operator authored role' do
+          expect(is_default_for build(:cluster_role)).to eq false
+        end
+
+        it 'is false for a role whose name merely contains a vendor prefix' do
+          expect(is_default_for build(:cluster_role, name: 'team-eks:admin')).to eq false
+        end
+
+        context 'with vendor managed roles opted out of via the environment' do
+
+          before { stub_const('ENV', ENV.to_h.merge('TREAT_VENDOR_MANAGED_ROLES_AS_DEFAULT' => 'false')) }
+
+          it 'is false for a vendor managed role' do
+            expect(is_default_for build(:cluster_role, :vendor_managed_by_name)).to eq false
+          end
+
+          it 'is still true for a role bootstrapped by Kubernetes' do
+            expect(is_default_for build(:cluster_role, :default)).to eq true
+          end
+
+        end
+
+      end
+
+    end
+
   end
 
 end

--- a/spec/lib/krane/rbac/graph/node_spec.rb
+++ b/spec/lib/krane/rbac/graph/node_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Krane::Rbac::Graph::Node do
         it 'builds network node title correctly' do
           title = subject.to_network[:title]
           expect(title).to include("#{subject.attrs[:kind]}: #{subject.attrs[:name]}")
-          expect(title).to include("- Default k8s role")
+          expect(title).to include("- Default role (Kubernetes or cloud provider managed)")
         end
 
         it 'builds network node group attribure correctly' do
@@ -143,7 +143,7 @@ RSpec.describe Krane::Rbac::Graph::Node do
         it 'builds node title attribute correctly' do
           title = subject.to_network[:title]
           expect(title).to include("#{subject.attrs[:kind]}: #{subject.attrs[:name]}")
-          expect(title).not_to include("- Default k8s role")
+          expect(title).not_to include("- Default role (Kubernetes or cloud provider managed)")
           expect(title).not_to include("- Aggregates rules defined in other cluster roles")
           expect(title).not_to include("- Can be aggregated by cluster roles: #{subject.attrs[:aggregable_by]}")
         end


### PR DESCRIPTION
Closes #326.

## The problem

Most risk rules skip roles the operator did not author, on the basis that a finding against a role nobody can edit is noise rather than a risk. Five templates in `query/template.rb` filter on `is_default: 'false'`, and role oriented rules do the same through `RISK_RULE_QUERY_EXCLUDE_DEFAULT_ROLES` in `query/builder.rb`.

That skip keyed off a single source: the `kubernetes.io/bootstrapping: rbac-defaults` label. It covered the roles Kubernetes bootstraps and nothing else.

Managed control planes install their own RBAC and reconcile it on the operator's behalf, and none of it carries that label. On EKS the report opens with `aws-node` and `eks:addon-manager` flagged as `danger` under `risky-any-resource-list` — findings the reader can neither act on nor suppress, since `whitelist_role_names` matches exact names only and the chart had no way to supply a whitelist at all. GKE, AKS and OpenShift all ship equivalent RBAC.

## The change

Fold vendor managed roles into `is_default` at graph build time, so every rule that already filters on it picks them up without a query change.

Detection is marker based rather than an enumeration of role names, which would go stale with each provider release. A role qualifies on a label the provider stamps on the RBAC it owns:

| Label | Provider |
|---|---|
| `eks.amazonaws.com/component` | EKS |
| `addonmanager.kubernetes.io/mode` | GKE, AKS |
| `kubernetes.azure.com/managedby` | AKS |

or on a name prefix it has reserved: `eks:`, `aws-node` (EKS); `gce:`, `system:gcp-`, `system:gke-` (GKE); `aks-`, `system:azure-` (AKS); `openshift-`, `system:openshift:` (OpenShift).

## Escape hatches

The classification is deliberately coarse, so it is escapable in both directions:

- `TREAT_VENDOR_MANAGED_ROLES_AS_DEFAULT=false` judges vendor roles like any other while leaving the Kubernetes defaults excluded. Exposed as `params.treatVendorManagedRolesAsDefault` in the chart.
- `RISK_RULE_QUERY_EXCLUDE_DEFAULT_ROLES=false` brings both back into the role oriented rules.
- `whitelist_role_names` still exempts individual roles by name.

## Notes

- **Prefix matching is coarse by design.** `aws-node` matches as a prefix, so `aws-node-anything` is covered too. A user role named `eks:foo` would be silently excluded - the inverse (`team-eks:admin` staying visible) is covered by a spec.
- **`k8s/` manifests and `docker-compose.yml` were left alone.** They get the default behaviour; opting out there means editing the file directly.
- The `is_default` node attribute now means "platform supplied" rather than strictly "Kubernetes bootstrapped". The network graph tooltip was reworded to match ("Default role (Kubernetes or cloud provider managed)"); the tree view's `Default` tag was already generic enough to leave alone.
- `helm template` renders `"true"` by default and `"false"` under `--set params.treatVendorManagedRolesAsDefault=false`.