### PR TITLE
Take apiGroups into account when matching risk rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,10 +372,13 @@ Rule can contain any of the following attributes:
   - Example:
     ```yaml
      match_rules:
-     - resources: ['cronjobs']
+     - apiGroups: ['batch']
+       resources: ['cronjobs']
        verbs: ['update']
     ```
      Attributes and values follow [Kubernetes RBAC role specification](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-examples).
+
+     Values of a given attribute are matched together (logical AND), so a role only matches when it grants all of them. `apiGroups` are the exception - a role rule names a single API group per resource, so their values are matched as alternatives (logical OR), and the `*` API group is always accepted alongside them. Omitting `apiGroups` matches a role rule naming *any* API group, which for a resource that exists in one group only (or for the `*` resource) reports a wider scope than the role actually grants.
 
 - `custom_params` [Optional] Map of custom key-value pairs to be evaluated and replaced in a rule `query` and `writer` representation.
   - Example:
@@ -447,7 +450,8 @@ Built-in templates simplify risk rule definition significantly, however, they ar
   info: Roles/ClusterRoles allowing all actions on secrets. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['secrets']
+  - apiGroups: ['']
+    resources: ['secrets']
     verbs: ['*']
 ```
 

--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -40,6 +40,10 @@ macros:
 #                      - risky-role : Builds multi-match graph query based on the access rule specified in :match_rules.
 #                                     Attributes and values in :match_rule follow Kubernetes spec at:
 #                                       * https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-examples
+#                                     Note: values of a given attribute are matched together (logical AND), so a role
+#                                     only matches when it grants ALL of them. :apiGroups are the exception - a role rule
+#                                     names a single API group per resource, so their values are alternatives (logical
+#                                     OR) and the `*` group is always accepted alongside them.
 #                                     Generated graph query returns the following columns: 
 #                                       * role_name
 #                                       * role_kind
@@ -47,7 +51,8 @@ macros:
 # :match_rules     - [Conditonal] Required when :template relies on match rules in order to build a query.
 #                    Example:
 #                      match_rules:
-#                      - resources: ['cronjobs']
+#                      - apiGroups: ['batch']
+#                        resources: ['cronjobs']
 #                        verbs: ['update']
 
 # :custom_params   - Map of custom key-value pairs to be replaced in resolved :query / :writer.
@@ -197,7 +202,8 @@ rules:
   info: Roles/ClusterRoles allowing to view specific secrets. This can be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['secrets']
+  - apiGroups: ['']
+    resources: ['secrets']
     verbs: ['get']
 
 - id: risky-list-secrets
@@ -206,7 +212,8 @@ rules:
   info: Roles/ClusterRoles allowing to list all secrets. This can be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['secrets']
+  - apiGroups: ['']
+    resources: ['secrets']
     verbs: ['list']
 
 # Impersonation
@@ -217,7 +224,8 @@ rules:
   info: Roles/ClusterRoles allowing to impersonate privileged groups. This is dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['groups']
+  - apiGroups: ['']
+    resources: ['groups']
     verbs: ['impersonate']
 
 # All actions (*) on specific resource
@@ -228,7 +236,8 @@ rules:
   info: Roles/ClusterRoles allowing all actions on secrets. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['secrets']
+  - apiGroups: ['']
+    resources: ['secrets']
     verbs: ['*']
 
 - id: risky-any-verb-pods
@@ -237,7 +246,8 @@ rules:
   info: Roles/ClusterRoles allowing all actions on pods. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['pods']
+  - apiGroups: ['']
+    resources: ['pods']
     verbs: ['*']
 
 - id: risky-any-verb-deployments
@@ -246,7 +256,8 @@ rules:
   info: Roles/ClusterRoles allowing all actions on deployments. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['deployments']
+  - apiGroups: ['apps']
+    resources: ['deployments']
     verbs: ['*']
 
 - id: risky-any-verb-daemonsets
@@ -255,7 +266,8 @@ rules:
   info: Roles/ClusterRoles allowing all actions on daemonsets. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['daemonsets']
+  - apiGroups: ['apps']
+    resources: ['daemonsets']
     verbs: ['*']
 
 - id: risky-any-verb-statefulsets
@@ -264,7 +276,8 @@ rules:
   info: Roles/ClusterRoles allowing all actions on statefulsets. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['statefulsets']
+  - apiGroups: ['apps']
+    resources: ['statefulsets']
     verbs: ['*']
 
 - id: risky-any-verb-replicationcontrollers
@@ -273,7 +286,8 @@ rules:
   info: Roles/ClusterRoles allowing all actions on replicationcontrollers. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['replicationcontrollers']
+  - apiGroups: ['']
+    resources: ['replicationcontrollers']
     verbs: ['*']
 
 - id: risky-any-verb-replicasets
@@ -282,7 +296,8 @@ rules:
   info: Roles/ClusterRoles allowing all actions on replicasets. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['replicasets']
+  - apiGroups: ['apps']
+    resources: ['replicasets']
     verbs: ['*']
 
 - id: risky-any-verb-cronjobs
@@ -291,7 +306,8 @@ rules:
   info: Roles/ClusterRoles allowing all actions on cronjobs. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['cronjobs']
+  - apiGroups: ['batch']
+    resources: ['cronjobs']
     verbs: ['*']
 
 - id: risky-any-verb-jobs
@@ -300,7 +316,8 @@ rules:
   info: Roles/ClusterRoles allowing all actions on jobs. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['jobs']
+  - apiGroups: ['batch']
+    resources: ['jobs']
     verbs: ['*']
 
 - id: risky-any-verb-roles
@@ -309,7 +326,8 @@ rules:
   info: Roles/ClusterRoles allowing all actions on roles. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['roles']
+  - apiGroups: ['rbac.authorization.k8s.io']
+    resources: ['roles']
     verbs: ['*']
 
 - id: risky-any-verb-clusterroles
@@ -318,7 +336,8 @@ rules:
   info: Roles/ClusterRoles allowing all actions on clusterroles. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['clusterroles']
+  - apiGroups: ['rbac.authorization.k8s.io']
+    resources: ['clusterroles']
     verbs: ['*']
 
 - id: risky-any-verb-rolebindings
@@ -327,7 +346,8 @@ rules:
   info: Roles/ClusterRoles allowing all actions on rolebindings. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['rolebindings']
+  - apiGroups: ['rbac.authorization.k8s.io']
+    resources: ['rolebindings']
     verbs: ['*']
 
 - id: risky-any-verb-clusterrolebindings
@@ -336,7 +356,8 @@ rules:
   info: Roles/ClusterRoles allowing all actions on clusterrolebindings. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['clusterrolebindings']
+  - apiGroups: ['rbac.authorization.k8s.io']
+    resources: ['clusterrolebindings']
     verbs: ['*']
 
 - id: risky-any-verb-users
@@ -345,7 +366,8 @@ rules:
   info: "Roles/ClusterRoles allowing all actions on users. This might be dangerous. Review listed Roles!"
   template: risky-role
   match_rules:
-  - resources: ['users']
+  - apiGroups: ['']
+    resources: ['users']
     verbs: ['*']
 
 - id: risky-any-verb-groups
@@ -354,7 +376,8 @@ rules:
   info: Roles/ClusterRoles allowing all actions on groups. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['groups']
+  - apiGroups: ['']
+    resources: ['groups']
     verbs: ['*']
 
 # Specific action on all (*) resources
@@ -365,7 +388,8 @@ rules:
   info: Roles/ClusterRoles allowing delete action on all resources. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['*']
+  - apiGroups: ['*']
+    resources: ['*']
     verbs: ['delete']
 
 - id: risky-any-resource-deletecollection
@@ -374,7 +398,8 @@ rules:
   info: Roles/ClusterRoles allowing deletecollection action on all resources. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['*']
+  - apiGroups: ['*']
+    resources: ['*']
     verbs: ['deletecollection']
 
 - id: risky-any-resource-create
@@ -383,7 +408,8 @@ rules:
   info: Roles/ClusterRoles allowing create action on all resources. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['*']
+  - apiGroups: ['*']
+    resources: ['*']
     verbs: ['create']
 
 - id: risky-any-resource-list
@@ -392,7 +418,8 @@ rules:
   info: Roles/ClusterRoles allowing list action on all resources. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['*']
+  - apiGroups: ['*']
+    resources: ['*']
     verbs: ['list']
 
 - id: risky-any-resource-get
@@ -401,7 +428,8 @@ rules:
   info: Roles/ClusterRoles allowing get action on all resources. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['*']
+  - apiGroups: ['*']
+    resources: ['*']
     verbs: ['get']
 
 - id: risky-any-resource-impersonate
@@ -410,7 +438,8 @@ rules:
   info: Roles/ClusterRoles allowing impersonate action on all resources. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['*']
+  - apiGroups: ['*']
+    resources: ['*']
     verbs: ['impersonate']
 
 # Malicious pod
@@ -421,7 +450,8 @@ rules:
   info: Roles/ClusterRoles allowing to create a potentially malicious pod. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['deployments']
+  - apiGroups: ['apps']
+    resources: ['deployments']
     verbs: ['create']
 
 - id: risky-update-deployments
@@ -430,7 +460,8 @@ rules:
   info: Roles/ClusterRoles allowing to update a potentially malicious pod. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['deployments']
+  - apiGroups: ['apps']
+    resources: ['deployments']
     verbs: ['update']
 
 - id: risky-create-daemonsets
@@ -439,7 +470,8 @@ rules:
   info: Roles/ClusterRoles allowing to create a potentially malicious daemonset. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['daemonsets']
+  - apiGroups: ['apps']
+    resources: ['daemonsets']
     verbs: ['create']
 
 - id: risky-update-daemonsets
@@ -448,7 +480,8 @@ rules:
   info: Roles/ClusterRoles allowing to update a potentially malicious daemonset. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['daemonsets']
+  - apiGroups: ['apps']
+    resources: ['daemonsets']
     verbs: ['update']
 
 - id: risky-create-statefulsets
@@ -457,7 +490,8 @@ rules:
   info: Roles/ClusterRoles allowing to create a potentially malicious statefulset. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['statefulsets']
+  - apiGroups: ['apps']
+    resources: ['statefulsets']
     verbs: ['create']
 
 - id: risky-update-statefulsets
@@ -466,7 +500,8 @@ rules:
   info: Roles/ClusterRoles allowing to update a potentially malicious statefulset. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['statefulsets']
+  - apiGroups: ['apps']
+    resources: ['statefulsets']
     verbs: ['update']
 
 - id: risky-create-replicationcontrollers
@@ -475,7 +510,8 @@ rules:
   info: Roles/ClusterRoles allowing to create a potentially malicious replicationcontroller. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['replicationcontrollers']
+  - apiGroups: ['']
+    resources: ['replicationcontrollers']
     verbs: ['create']
 
 - id: risky-update-replicationcontrollers
@@ -484,7 +520,8 @@ rules:
   info: Roles/ClusterRoles allowing to update a potentially malicious replicationcontroller. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['replicationcontrollers']
+  - apiGroups: ['']
+    resources: ['replicationcontrollers']
     verbs: ['update']
 
 - id: risky-create-replicasets
@@ -493,7 +530,8 @@ rules:
   info: Roles/ClusterRoles allowing to create a potentially malicious replicaset. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['replicasets']
+  - apiGroups: ['apps']
+    resources: ['replicasets']
     verbs: ['create']
 
 - id: risky-update-replicasets
@@ -502,7 +540,8 @@ rules:
   info: Roles/ClusterRoles allowing to update a potentially malicious replicaset. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['replicasets']
+  - apiGroups: ['apps']
+    resources: ['replicasets']
     verbs: ['update']
 
 - id: risky-create-jobs
@@ -511,7 +550,8 @@ rules:
   info: Roles/ClusterRoles allowing to create a potentially malicious job. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['jobs']
+  - apiGroups: ['batch']
+    resources: ['jobs']
     verbs: ['create']
 
 - id: risky-update-jobs
@@ -520,7 +560,8 @@ rules:
   info: Roles/ClusterRoles allowing to update a potentially malicious job. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['jobs']
+  - apiGroups: ['batch']
+    resources: ['jobs']
     verbs: ['update']
 
 - id: risky-create-cronjobs
@@ -529,7 +570,8 @@ rules:
   info: Roles/ClusterRoles allowing to create a potentially malicious cronjob. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['cronjobs']
+  - apiGroups: ['batch']
+    resources: ['cronjobs']
     verbs: ['create']
 
 - id: risky-update-cronjobs
@@ -538,7 +580,8 @@ rules:
   info: Roles/ClusterRoles allowing to update a potentially malicious cronjob. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['cronjobs']
+  - apiGroups: ['batch']
+    resources: ['cronjobs']
     verbs: ['update']
 
 # Multiple permissions simulaneously
@@ -587,9 +630,11 @@ rules:
   info: Roles allow exec into running container. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['pods/exec']
+  - apiGroups: ['']
+    resources: ['pods/exec']
     verbs: ['create']
-  - resources: ['pods']
+  - apiGroups: ['']
+    resources: ['pods']
     verbs: ['get']
 
 - id: risky-attach-pods 
@@ -598,9 +643,11 @@ rules:
   info: Roles allow attaching to a running container. This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['pods/attach']
+  - apiGroups: ['']
+    resources: ['pods/attach']
     verbs: ['create']
-  - resources: ['pods']
+  - apiGroups: ['']
+    resources: ['pods']
     verbs: ['get']
 
 # Low priority
@@ -611,5 +658,6 @@ rules:
   info: This might be dangerous. Review listed Roles!
   template: risky-role
   match_rules:
-  - resources: ['rolebindings']
+  - apiGroups: ['rbac.authorization.k8s.io']
+    resources: ['rolebindings']
     verbs: ['patch', 'get']

--- a/lib/krane/report/risk_rule/query/builder.rb
+++ b/lib/krane/report/risk_rule/query/builder.rb
@@ -25,9 +25,13 @@ module Krane
           # NOTE: Multiple :match_rules will be evaluated with logical AND
           #       so ONLY roles with intersecting matches will be selected
           #
+          # NOTE: apiGroups are the one exception - their entries are alternatives (logical OR),
+          #       since a role rule names a single API group per resource, and the `*` wildcard
+          #       role rules use to mean "every API group" has to match too.
+          #
           # :match_rules example:
           #
-          # - apiGroups: ['*', 'core']
+          # - apiGroups: ['rbac.authorization.k8s.io']
           #   resources: ['rolebindings', 'pods']
           #   verbs: ['patch', 'get']
           # - nonResourceURLs: ['/healthz']
@@ -51,8 +55,8 @@ module Krane
           # Example:
           #
           # [
-          #   {:type=>"resource", :api_group=>"rbac.authorization.k8s.io", :resource=>"rolebindings", :verb=>"create"},
-          #   {:type=>"resource", :api_group=>"rbac.authorization.k8s.io", :resource=>"roles", :verb=>"bind"}
+          #   {:type=>"resource", :api_groups=>["rbac.authorization.k8s.io", "*"], :resource=>"rolebindings", :verb=>"create"},
+          #   {:type=>"resource", :api_groups=>["rbac.authorization.k8s.io", "*"], :resource=>"roles", :verb=>"bind"}
           # ]
           #
           def build_rule_selectors item:
@@ -70,21 +74,32 @@ module Krane
             role_attrs = exclude_default_roles ? "{is_default: 'false'}" : ''
 
             rule_selectors.collect.with_index do |selector, index|
-              rule_selector = selector.map do |k,v|
+              # :api_groups holds alternatives, which a node property map cannot express as it
+              # tests for equality - build_where matches those instead.
+              rule_selector = selector.except(:api_groups).map do |k,v|
                 "#{k}: '#{v}'"
               end.join(', ')
 
-              "MATCH (ns:Namespace)<-[:SCOPE]-(ro#{index}:Role #{role_attrs})<-[:GRANT]-(:Rule {#{rule_selector}})"
+              "MATCH (ns:Namespace)<-[:SCOPE]-(ro#{index}:Role #{role_attrs})<-[:GRANT]-(ru#{index}:Rule {#{rule_selector}})"
             end
           end
 
-          # Builds graph query WHERE condition for multi-MATCH queries
+          # Builds graph query WHERE conditions for supplied list of selectors:
+          # - the API groups a matched role rule is allowed to name, one condition per selector
+          # - the conditions tying every match of a multi-MATCH query to the same role
           def build_where rule_selectors: []
-            return [] if rule_selectors.size == 1
-
-            0.upto(rule_selectors.size-2).collect do |index|
-              "ID(ro0) = ID(ro#{index+1})"
+            same_role = if rule_selectors.size > 1
+              1.upto(rule_selectors.size-1).collect { |index| "ID(ro0) = ID(ro#{index})" }
+            else
+              []
             end
+
+            api_groups = rule_selectors.each_with_index.filter_map do |selector, index|
+              next if selector[:api_groups].blank?
+              "ru#{index}.api_group IN [#{selector[:api_groups].map {|g| "'#{g}'" }.join(', ')}]"
+            end
+
+            same_role + api_groups
           end
 
         end

--- a/lib/krane/report/risk_rule/query/rule_selector.rb
+++ b/lib/krane/report/risk_rule/query/rule_selector.rb
@@ -19,7 +19,14 @@ module Krane
     module RiskRule
       module Query
         class RuleSelector
-          
+
+          # The core API group, spelled `""` in a Kubernetes role rule and stored as `core` in
+          # the graph (see Rbac::Graph::Concerns::RoleAccessRules#process_resource_rule).
+          CORE_API_GROUP = 'core'
+
+          # Wildcard a role rule uses to mean "every API group".
+          ANY_API_GROUP = '*'
+
           def initialize attrs = {}
             @non_resource_urls = attrs.fetch(:nonResourceURLs, [])
             @api_groups        = attrs.fetch(:apiGroups, [])
@@ -37,11 +44,18 @@ module Krane
 
           # Builds RBAC Rule selectors based on instance attributes
           #
+          # Every attribute apart from the API groups selects a single value, so the selectors are
+          # the product of them - the query builder emits one graph MATCH per selector and requires
+          # all of them to hit the same role. API groups are the exception: their entries are
+          # alternatives, so they are carried on the selector as an :api_groups list for the builder
+          # to match in a single condition, rather than being multiplied out into MATCHes that no
+          # role rule can satisfy at once.
+          #
           # @return [Array] an array of rule attribute selectors
           def selectors
             if resource_rule? # Resource specific rules
               i = [{type: 'resource'}]
-              i = i.product(api_groups) if api_groups.any?
+              i = i.product([{api_groups: api_groups}]) if api_groups.any?
               i = i.product(resources)  if resources.any?
               i = i.product(verbs)      if verbs.any?
             else # Non-resource URLs rules
@@ -57,8 +71,12 @@ module Krane
 
           private
 
+          # API groups a role rule may name to be considered a match. `''`, as written in a
+          # Kubernetes role rule, is normalised to the `core` the graph stores, and the `*` wildcard
+          # is always accepted - a role rule granting every API group grants this one too.
           def api_groups
-            @api_groups.map {|i| {api_group: i}}        
+            return [] if @api_groups.empty?
+            @api_groups.map {|i| i.blank? ? CORE_API_GROUP : i }.push(ANY_API_GROUP).uniq
           end
 
           def resources

--- a/spec/config/rules_spec.rb
+++ b/spec/config/rules_spec.rb
@@ -59,6 +59,46 @@ RSpec.describe 'the shipped risk rules' do
     expect(unresolvable).to be_empty
   end
 
+  # Issue #80: a match rule that names no apiGroups matches a role rule naming ANY API group,
+  # so a `*` resource scoped to one CRD group was reported as access to every resource, and a
+  # `secrets` rule matched a CRD of the same name in an unrelated group.
+  it 'scopes every match rule to the API groups its resources live in' do
+    unscoped = Krane::Config::Risk.new.rules.each_with_object({}) do |rule, hsh|
+      found = rule[:match_rules].to_a.reject do |match_rule|
+        # Non-resource URL rules are not part of any API group.
+        match_rule[:nonResourceURLs].present? || match_rule[:apiGroups].present?
+      end
+
+      hsh[rule[:id]] = found if found.any?
+    end
+
+    expect(unscoped).to be_empty
+  end
+
+  describe 'risky-any-resource-get' do
+
+    subject { rule('risky-any-resource-get') }
+
+    # The rule reported in issue #80. `*` resources within a single API group is what every
+    # operator's own ClusterRole grants, and is not access to all resources.
+    it 'only matches a rule granting the wildcard API group' do
+      expect(subject[:query]).to include %q(ru0.api_group IN ['*'])
+    end
+
+  end
+
+  describe 'risky-get-secrets' do
+
+    subject { rule('risky-get-secrets') }
+
+    # `''` in the rule definition, `core` in the graph - and a role rule granting every API
+    # group grants the core one too.
+    it 'matches a rule granting the core API group, or every API group' do
+      expect(subject[:query]).to include %q(ru0.api_group IN ['core', '*'])
+    end
+
+  end
+
   # A finding's items are marker-rendered, so `name_of(...)` becomes bold in the dashboard. Its
   # `info` is not - FindingCard.vue interpolates it as plain text - so a backtick written there
   # reaches the user as a literal character.

--- a/spec/lib/krane/report/risk_rule/query/builder_spec.rb
+++ b/spec/lib/krane/report/risk_rule/query/builder_spec.rb
@@ -33,13 +33,15 @@ RSpec.describe Krane::Report::RiskRule::Query::Builder do
 
       let(:expected_matches) do
         [
-        "MATCH (ns:Namespace)<-[:SCOPE]-(ro0:Role {is_default: 'false'})<-[:GRANT]-(:Rule {type: 'resource', api_group: 'rbac.authorization.k8s.io', resource: 'rolebindings', verb: 'create'})",
-        "MATCH (ns:Namespace)<-[:SCOPE]-(ro1:Role {is_default: 'false'})<-[:GRANT]-(:Rule {type: 'resource', api_group: 'rbac.authorization.k8s.io', resource: 'clusterroles', verb: 'bind'})"
+        "MATCH (ns:Namespace)<-[:SCOPE]-(ro0:Role {is_default: 'false'})<-[:GRANT]-(ru0:Rule {type: 'resource', resource: 'rolebindings', verb: 'create'})",
+        "MATCH (ns:Namespace)<-[:SCOPE]-(ro1:Role {is_default: 'false'})<-[:GRANT]-(ru1:Rule {type: 'resource', resource: 'clusterroles', verb: 'bind'})"
         ].join("\n")
       end
 
       let(:expected_where) do
-        %Q(ID(ro0) = ID(ro1))
+        %Q(ID(ro0) = ID(ro1) AND ) +
+        %Q(ru0.api_group IN ['rbac.authorization.k8s.io', '*'] AND ) +
+        %Q(ru1.api_group IN ['rbac.authorization.k8s.io', '*'])
       end
 
       it 'will get query for given template name with correct match rules and where conditions' do
@@ -49,6 +51,38 @@ RSpec.describe Krane::Report::RiskRule::Query::Builder do
             kind: @item[:template], 
             matches: expected_matches, 
             where: expected_where
+          ) { tpl }
+
+        subject.for(item: @item)
+      end
+
+    end
+
+    # The crux of issue #80: a role rule granting `*` resources within one API group used to be
+    # matched by a rule looking for `*` resources, and so reported as access to everything.
+    context 'for a match rule scoped to the wildcard API group' do
+
+      let(:risk) do
+        build(
+          :risk, :with_default_template_based_rule,
+          default_rule_match_rules: [
+            {
+              apiGroups: ['*'],
+              resources: ['*'],
+              verbs: ['get'],
+            }
+          ]
+        )
+      end
+
+      it 'constrains the API group of the matched rule' do
+        expect(Krane::Report::RiskRule::Query::Template)
+          .to receive(:for)
+          .with(
+            kind: @item[:template],
+            matches: "MATCH (ns:Namespace)<-[:SCOPE]-(ro0:Role {is_default: 'false'})" \
+                     "<-[:GRANT]-(ru0:Rule {type: 'resource', resource: '*', verb: 'get'})",
+            where: %Q(ru0.api_group IN ['*'])
           ) { tpl }
 
         subject.for(item: @item)

--- a/spec/lib/krane/report/risk_rule/query/rule_selector_spec.rb
+++ b/spec/lib/krane/report/risk_rule/query/rule_selector_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Krane::Report::RiskRule::Query::RuleSelector do
 
     context 'for resource specific rules' do
 
+      # API groups are alternatives: a role rule names one API group per resource, so a selector
+      # per group would build a query no role can satisfy. They stay on the selector as a list.
       context 'with apiGroups specified' do
 
         let(:attrs) do
@@ -16,9 +18,8 @@ RSpec.describe Krane::Report::RiskRule::Query::RuleSelector do
         end
 
         it 'returns expected array of selectors hashes' do
-          expect(subject.selectors).to include(
-            {:api_group=>"g1", :resource=>"r1", :type=>"resource"},
-            {:api_group=>"g2", :resource=>"r1", :type=>"resource"}
+          expect(subject.selectors).to eq(
+            [{:type=>"resource", :api_groups=>["g1", "g2", "*"], :resource=>"r1"}]
           )
         end
 
@@ -35,10 +36,59 @@ RSpec.describe Krane::Report::RiskRule::Query::RuleSelector do
 
         it 'returns expected array of selectors hashes' do
           expect(subject.selectors).to include(
-            {:api_group=>"g1", :resource=>"r1", :type=>"resource", :verb=>"get"},
-            {:api_group=>"g1", :resource=>"r1", :type=>"resource", :verb=>"list"},
-            {:api_group=>"g2", :resource=>"r1", :type=>"resource", :verb=>"get"},
-            {:api_group=>"g2", :resource=>"r1", :type=>"resource", :verb=>"list"}
+            {:type=>"resource", :api_groups=>["g1", "g2", "*"], :resource=>"r1", :verb=>"get"},
+            {:type=>"resource", :api_groups=>["g1", "g2", "*"], :resource=>"r1", :verb=>"list"}
+          )
+        end
+
+      end
+
+      context 'with the core apiGroup specified' do
+
+        let(:attrs) do
+          {
+            apiGroups: [''],
+            resources: ['secrets']
+          }
+        end
+
+        it 'matches the `core` group the graph stores for it' do
+          expect(subject.selectors).to eq(
+            [{:type=>"resource", :api_groups=>["core", "*"], :resource=>"secrets"}]
+          )
+        end
+
+      end
+
+      context 'with the wildcard apiGroup specified' do
+
+        let(:attrs) do
+          {
+            apiGroups: ['*'],
+            resources: ['*']
+          }
+        end
+
+        it 'matches the wildcard group only' do
+          expect(subject.selectors).to eq(
+            [{:type=>"resource", :api_groups=>["*"], :resource=>"*"}]
+          )
+        end
+
+      end
+
+      context 'without apiGroups specified' do
+
+        let(:attrs) do
+          {
+            resources: ['r1'],
+            verbs: ['get']
+          }
+        end
+
+        it 'leaves the API group unconstrained' do
+          expect(subject.selectors).to eq(
+            [{:type=>"resource", :resource=>"r1", :verb=>"get"}]
           )
         end
 


### PR DESCRIPTION
Closes #80.

## The problem

A risk rule's `match_rules` named resources and verbs but no API group, so `Query::Builder` selected a `Rule` node on those two properties alone:

```
MATCH (ns:Namespace)<-[:SCOPE]-(ro0:Role {is_default: 'false'})<-[:GRANT]-(:Rule {type: 'resource', resource: '*', verb: 'get'})
```

A graph node property map is a subset test, so any `api_group` satisfied it.

That is what #80 reported. A ClusterRole granting `get` on `*` resources within `metal3.io`:

```yaml
- apiGroups: [metal3.io]
  resources: ['*']
  verbs: [get, create, list]
```

was matched by `risky-any-resource-get` and reported as *"get action on all resources"*, when the grant covers one CRD group. Every operator ships a ClusterRole shaped like that, so the report opened with danger findings the reader could only dismiss.

The same hole works in the other direction - `resources: ['secrets']` in a match rule also matched a CRD called `secrets` in an unrelated group - and it undercut the handful of rules that *did* name `apiGroups`: those were matched by exact property equality, so a role granting `create rolebindings` in `*` never matched `risky-create-rolebinding-role` at all.

## The fix

Give the shipped match rules the API groups their resources actually live in, and match those groups as alternatives rather than as another dimension of the selector product.

The product matters here. `RuleSelector` multiplies its attributes together and the builder emits one `MATCH` per selector, all tied to the same role - so values of an attribute are ANDed. A role rule names a single API group per resource, so a `MATCH` per group would build a query no role can satisfy. The groups are instead carried on the selector as an `:api_groups` list and become one condition on the now-named `Rule` node:

```
MATCH (ns:Namespace)<-[:SCOPE]-(ro0:Role {is_default: 'false'})<-[:GRANT]-(ru0:Rule {type: 'resource', resource: 'secrets', verb: 'get'})
WHERE ru0.api_group IN ['core', '*'] AND NOT ro0.name IN [...]
```

`''`, as written in a Kubernetes role rule, is normalised to the `core` the graph stores. `*` is always accepted alongside whatever the rule asks for, since a role rule granting every API group grants that one too - which is what fixes the false negative above.

`config/rules.yaml` gains `apiGroups` on all 43 unscoped match rules: `''` for pods/secrets/replicationcontrollers/users/groups, `apps`, `batch`, `rbac.authorization.k8s.io`, and `['*']` for the `resources: ['*']` rules.

## Two deliberate calls

**The `*` resource rules are scoped to the `*` API group**, so a wildcard grant confined to a single API group is no longer reported at all. That is precisely the finding #80 objected to: reporting it under a title claiming all resources is what made the report unactionable.

**Groups are the current ones only.** `extensions` deployments and friends grant nothing on Kubernetes >= 1.16, so including them would flag dead config as effective access. An operator still running older clusters can override `match_rules` per rule id in `custom-rules.yaml`, since `Config::Risk#rules` deep merges by id and arrays replace.

## Verification

Beyond the unit specs, the branch was diffed against `master` over the full pipeline - ingest, FalkorDB, all 55 rules - on a synthetic corpus of 13 ClusterRoles, 4 Roles and 17 bindings covering every rule family with correct group, wrong group and wildcard group variants, including the ClusterRole from #80 verbatim. 13 rules changed, all intentional:

| dropped | why it was wrong |
| --- | --- |
| `collins-operator` from get/list/create on all resources | `metal3.io/*` - the issue |
| `scoped-wildcard-verbs` from delete, deletecollection, create, list, impersonate on all resources | `metal3.io/*` |
| `crd-secrets-lookalike` from get/list/all-actions on secrets | `example.io/secrets` |
| `ns-crd-secret-reader` from get/list secrets | `example.io/secrets` in a namespace |
| `ns-crd-rolebinding-adder` from risky-add-rolebinding | `fake.io/rolebindings` |
| `metrics-pods-viewer` from all actions on pods | `metrics.k8s.io/pods` |
| `legacy-extensions-deployer` from all actions on deployments | `extensions/deployments`, inert on >= 1.16 |

| added | why it was missed |
| --- | --- |
| `rbac-manager-wildcard-group` to `risky-create-rolebinding-role` | granted `rolebindings/create` + `roles/bind` through `apiGroups: ['*']` |

Every true positive was retained, including `collins-operator` under `risky-get-secrets` and `risky-list-secrets` for its real core secrets grant, and `wildcard-group-secrets` matching via the `*` group. The same corpus was then applied to a live kind cluster and both versions run through `--kubecontext`, exercising fetch → cache → index → report: byte identical diff.

## Related

#529 covers the mirror image of this gap, found while working on it: `resource` and `verb` are still matched by exact equality, so a role granting `verbs: ['*']` or `resources: ['*']` is not matched by a rule naming a concrete value.