### PR TITLE
WIP: Match risk rules against wildcard verbs and resources (#529)

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,11 @@ Rule can contain any of the following attributes:
     ```
      Attributes and values follow [Kubernetes RBAC role specification](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-examples).
 
-     Values of a given attribute are matched together (logical AND), so a role only matches when it grants all of them. `apiGroups` are the exception - a role rule names a single API group per resource, so their values are matched as alternatives (logical OR), and the `*` API group is always accepted alongside them. Omitting `apiGroups` matches a role rule naming *any* API group, which for a resource that exists in one group only (or for the `*` resource) reports a wider scope than the role actually grants.
+     Values of a given attribute are matched together (logical AND), so a role only matches when it grants all of them. `apiGroups` are the exception - a role rule names a single API group per resource, so their values are matched as alternatives (logical OR). Omitting `apiGroups` matches a role rule naming *any* API group, which for a resource that exists in one group only (or for the `*` resource) reports a wider scope than the role actually grants.
+
+     The `*` wildcard a role rule may grant in place of an API group, a resource or a verb covers whatever the match rule names, so it is accepted alongside it: the example above matches a role granting `update` on `cronjobs`, and equally one granting `verbs: ['*']`, `resources: ['*']` or `apiGroups: ['*']`. A `nonResourceURLs` value is matched as written, since RBAC matches a URL by prefix and `*` is only one of the patterns that can cover it.
+
+     One grant is left out: every verb on every resource of the `*` API group. That role can do anything, which is not a specific risk to report against a named resource and verb - `unrestricted-cluster-wide-subjects` and `unrestricted-ns-level-subjects` report it in those words instead, for every subject it reaches. Without that exclusion such a role would appear under every `risky-role` rule there is, burying the findings a reader can act on. A role rule naming an API group is not excluded, `core` included - it grants nothing outside that group, so the resources it does cover are still worth naming.
 
 - `custom_params` [Optional] Map of custom key-value pairs to be evaluated and replaced in a rule `query` and `writer` representation.
   - Example:

--- a/config/rules.yaml
+++ b/config/rules.yaml
@@ -43,7 +43,13 @@ macros:
 #                                     Note: values of a given attribute are matched together (logical AND), so a role
 #                                     only matches when it grants ALL of them. :apiGroups are the exception - a role rule
 #                                     names a single API group per resource, so their values are alternatives (logical
-#                                     OR) and the `*` group is always accepted alongside them.
+#                                     OR).
+#                                     Note: the `*` wildcard a role rule may grant in place of an API group, a resource
+#                                     or a verb covers whatever the match rule names, so it is accepted alongside it.
+#                                     A role rule granting every verb on every resource of the `*` API group is the
+#                                     one exception - `unrestricted-cluster-wide-subjects` and
+#                                     `unrestricted-ns-level-subjects` report that in the words that fit it. A rule
+#                                     naming an API group is not excluded, `core` included.
 #                                     Generated graph query returns the following columns: 
 #                                       * role_name
 #                                       * role_kind

--- a/lib/krane/report/risk_rule/query/builder.rb
+++ b/lib/krane/report/risk_rule/query/builder.rb
@@ -26,8 +26,10 @@ module Krane
           #       so ONLY roles with intersecting matches will be selected
           #
           # NOTE: apiGroups are the one exception - their entries are alternatives (logical OR),
-          #       since a role rule names a single API group per resource, and the `*` wildcard
-          #       role rules use to mean "every API group" has to match too.
+          #       since a role rule names a single API group per resource.
+          #
+          # NOTE: the `*` wildcard a role rule grants in place of an API group, a resource or a verb
+          #       covers whatever the match rule names, so it is accepted alongside it.
           #
           # :match_rules example:
           #
@@ -55,8 +57,8 @@ module Krane
           # Example:
           #
           # [
-          #   {:type=>"resource", :api_groups=>["rbac.authorization.k8s.io", "*"], :resource=>"rolebindings", :verb=>"create"},
-          #   {:type=>"resource", :api_groups=>["rbac.authorization.k8s.io", "*"], :resource=>"roles", :verb=>"bind"}
+          #   {:type=>"resource", :api_group=>["rbac.authorization.k8s.io", "*"], :resource=>["rolebindings", "*"], :verb=>["create", "*"]},
+          #   {:type=>"resource", :api_group=>["rbac.authorization.k8s.io", "*"], :resource=>["roles", "*"], :verb=>["bind", "*"]}
           # ]
           #
           def build_rule_selectors item:
@@ -74,9 +76,9 @@ module Krane
             role_attrs = exclude_default_roles ? "{is_default: 'false'}" : ''
 
             rule_selectors.collect.with_index do |selector, index|
-              # :api_groups holds alternatives, which a node property map cannot express as it
-              # tests for equality - build_where matches those instead.
-              rule_selector = selector.except(:api_groups).map do |k,v|
+              # A list-valued attribute holds alternatives, which a node property map cannot express
+              # as it tests for equality - build_where matches those instead.
+              rule_selector = selector.reject {|_,v| v.is_a?(Array) }.map do |k,v|
                 "#{k}: '#{v}'"
               end.join(', ')
 
@@ -85,8 +87,10 @@ module Krane
           end
 
           # Builds graph query WHERE conditions for supplied list of selectors:
-          # - the API groups a matched role rule is allowed to name, one condition per selector
           # - the conditions tying every match of a multi-MATCH query to the same role
+          # - the alternatives a matched role rule may name for a list-valued attribute, which the
+          #   node property map of its MATCH cannot express
+          # - the exclusion of a role rule granting unrestricted access
           def build_where rule_selectors: []
             same_role = if rule_selectors.size > 1
               1.upto(rule_selectors.size-1).collect { |index| "ID(ro0) = ID(ro#{index})" }
@@ -94,12 +98,39 @@ module Krane
               []
             end
 
-            api_groups = rule_selectors.each_with_index.filter_map do |selector, index|
-              next if selector[:api_groups].blank?
-              "ru#{index}.api_group IN [#{selector[:api_groups].map {|g| "'#{g}'" }.join(', ')}]"
+            alternatives = rule_selectors.each_with_index.flat_map do |selector, index|
+              selector.select {|_,v| v.is_a?(Array) }.map do |attribute, values|
+                "ru#{index}.#{attribute} IN [#{values.map {|v| "'#{v}'" }.join(', ')}]"
+              end
             end
 
-            same_role + api_groups
+            same_role + alternatives + build_unrestricted_exclusions(rule_selectors: rule_selectors)
+          end
+
+          # Builds the conditions excluding a role rule that grants unrestricted access.
+          #
+          # Every verb on every resource of every API group is not one specific risk, it is a role
+          # that can do anything - which `unrestricted-cluster-wide-subjects` and
+          # `unrestricted-ns-level-subjects` already report in those words, for every subject it
+          # reaches. Accepting the wildcard in place of a named resource and verb would otherwise
+          # list such a role under every risky-role rule there is, burying the findings a reader can
+          # act on under one they cannot.
+          #
+          # A role rule naming an API group is NOT excluded, `core` included: it grants nothing
+          # outside that group, so the resources it does cover are worth naming. Those two templates
+          # additionally treat `core` as unrestricted, which is a fair reading of what a subject can
+          # reach through it, but it does not follow that every resource in the group goes unnamed.
+          #
+          # Only resource selectors need this: `nonResourceURLs` are matched as written, since RBAC
+          # matches a URL by prefix and `*` is only one of the patterns that can cover it.
+          def build_unrestricted_exclusions rule_selectors: []
+            rule_selectors.each_with_index.filter_map do |selector, index|
+              next unless selector.key?(:resource)
+
+              "NOT (ru#{index}.api_group = '#{RuleSelector::WILDCARD}' " \
+                "AND ru#{index}.resource = '#{RuleSelector::WILDCARD}' " \
+                "AND ru#{index}.verb = '#{RuleSelector::WILDCARD}')"
+            end
           end
 
         end

--- a/lib/krane/report/risk_rule/query/rule_selector.rb
+++ b/lib/krane/report/risk_rule/query/rule_selector.rb
@@ -24,8 +24,8 @@ module Krane
           # the graph (see Rbac::Graph::Concerns::RoleAccessRules#process_resource_rule).
           CORE_API_GROUP = 'core'
 
-          # Wildcard a role rule uses to mean "every API group".
-          ANY_API_GROUP = '*'
+          # Wildcard a role rule uses to mean "every API group", "every resource" or "every verb".
+          WILDCARD = '*'
 
           def initialize attrs = {}
             @non_resource_urls = attrs.fetch(:nonResourceURLs, [])
@@ -47,15 +47,19 @@ module Krane
           # Every attribute apart from the API groups selects a single value, so the selectors are
           # the product of them - the query builder emits one graph MATCH per selector and requires
           # all of them to hit the same role. API groups are the exception: their entries are
-          # alternatives, so they are carried on the selector as an :api_groups list for the builder
-          # to match in a single condition, rather than being multiplied out into MATCHes that no
-          # role rule can satisfy at once.
+          # alternatives, so a single selector carries all of them, rather than being multiplied out
+          # into MATCHes that no role rule can satisfy at once.
+          #
+          # A selector value is either a single value the matched rule's property must equal, or a
+          # list of alternatives any one of which will do. The API groups are always a list; a
+          # resource or a verb becomes one because the `*` a role rule may grant in its place covers
+          # the named value too.
           #
           # @return [Array] an array of rule attribute selectors
           def selectors
             if resource_rule? # Resource specific rules
               i = [{type: 'resource'}]
-              i = i.product([{api_groups: api_groups}]) if api_groups.any?
+              i = i.product([{api_group: api_groups}]) if api_groups.any?
               i = i.product(resources)  if resources.any?
               i = i.product(verbs)      if verbs.any?
             else # Non-resource URLs rules
@@ -76,20 +80,30 @@ module Krane
           # is always accepted - a role rule granting every API group grants this one too.
           def api_groups
             return [] if @api_groups.empty?
-            @api_groups.map {|i| i.blank? ? CORE_API_GROUP : i }.push(ANY_API_GROUP).uniq
+            with_wildcard(@api_groups.map {|i| i.blank? ? CORE_API_GROUP : i })
           end
 
           def resources
-            @resources.map {|i| {resource: i}}
+            @resources.map {|i| {resource: with_wildcard(i)}}
           end
 
           def verbs
-            @verbs.map {|i| {verb: i}}
+            @verbs.map {|i| {verb: with_wildcard(i)}}
           end
 
+          # Non-resource URLs are left as written: RBAC matches them by prefix, so `*` is one of
+          # several patterns a role rule may use to cover a URL and singling it out would be
+          # arbitrary. No shipped rule matches on them.
           def urls
             @non_resource_urls.map {|i| {url: i}}
           end
+
+          # A role rule granting the wildcard grants whatever the match rule names, so accept it
+          # alongside. Values already asking for the wildcard are left as they are.
+          def with_wildcard values
+            (Array(values) + [WILDCARD]).uniq
+          end
+
         end
 
       end

--- a/spec/config/rules_spec.rb
+++ b/spec/config/rules_spec.rb
@@ -97,6 +97,39 @@ RSpec.describe 'the shipped risk rules' do
       expect(subject[:query]).to include %q(ru0.api_group IN ['core', '*'])
     end
 
+    # Issue #529: a role granting `verbs: ['*']` on secrets, or `get` on `resources: ['*']`
+    # within the core group, allows viewing secrets and used not to be matched at all.
+    it 'matches a rule granting the wildcard resource, or the wildcard verb' do
+      expect(subject[:query]).to include %q(ru0.resource IN ['secrets', '*'])
+      expect(subject[:query]).to include %q(ru0.verb IN ['get', '*'])
+    end
+
+  end
+
+  # Issue #529, second half. Accepting the wildcard in place of a named resource and verb means a
+  # role granting everything matches every risky-role rule there is, which buries the findings a
+  # reader can act on. `unrestricted-cluster-wide-subjects` and `unrestricted-ns-level-subjects`
+  # report that role in the words that fit it, so the risky-role rules stop short of it.
+  #
+  # Only the wildcard API group is excluded. A role rule naming a group - `core` included - grants
+  # nothing outside it, so the resources it does cover stay worth naming.
+  it 'excludes a role rule granting unrestricted access from every resource match rule' do
+    matching = Krane::Config::Risk.new.rules.select { |item| item[:match_rules].to_a.any? }
+
+    unguarded = matching.reject do |item|
+      resource_rules = item[:match_rules].count { |match_rule| match_rule[:resources].present? }
+      query          = rule(item[:id])[:query]
+
+      resource_rules.times.all? do |index|
+        query.include?(
+          "NOT (ru#{index}.api_group = '*' " \
+          "AND ru#{index}.resource = '*' AND ru#{index}.verb = '*')"
+        )
+      end
+    end
+
+    expect(matching).not_to be_empty
+    expect(unguarded.map { |item| item[:id] }).to be_empty
   end
 
   # A finding's items are marker-rendered, so `name_of(...)` becomes bold in the dashboard. Its

--- a/spec/lib/krane/report/risk_rule/query/builder_spec.rb
+++ b/spec/lib/krane/report/risk_rule/query/builder_spec.rb
@@ -33,15 +33,21 @@ RSpec.describe Krane::Report::RiskRule::Query::Builder do
 
       let(:expected_matches) do
         [
-        "MATCH (ns:Namespace)<-[:SCOPE]-(ro0:Role {is_default: 'false'})<-[:GRANT]-(ru0:Rule {type: 'resource', resource: 'rolebindings', verb: 'create'})",
-        "MATCH (ns:Namespace)<-[:SCOPE]-(ro1:Role {is_default: 'false'})<-[:GRANT]-(ru1:Rule {type: 'resource', resource: 'clusterroles', verb: 'bind'})"
+        "MATCH (ns:Namespace)<-[:SCOPE]-(ro0:Role {is_default: 'false'})<-[:GRANT]-(ru0:Rule {type: 'resource'})",
+        "MATCH (ns:Namespace)<-[:SCOPE]-(ro1:Role {is_default: 'false'})<-[:GRANT]-(ru1:Rule {type: 'resource'})"
         ].join("\n")
       end
 
       let(:expected_where) do
         %Q(ID(ro0) = ID(ro1) AND ) +
         %Q(ru0.api_group IN ['rbac.authorization.k8s.io', '*'] AND ) +
-        %Q(ru1.api_group IN ['rbac.authorization.k8s.io', '*'])
+        %Q(ru0.resource IN ['rolebindings', '*'] AND ) +
+        %Q(ru0.verb IN ['create', '*'] AND ) +
+        %Q(ru1.api_group IN ['rbac.authorization.k8s.io', '*'] AND ) +
+        %Q(ru1.resource IN ['clusterroles', '*'] AND ) +
+        %Q(ru1.verb IN ['bind', '*'] AND ) +
+        %Q(NOT (ru0.api_group = '*' AND ru0.resource = '*' AND ru0.verb = '*') AND ) +
+        %Q(NOT (ru1.api_group = '*' AND ru1.resource = '*' AND ru1.verb = '*'))
       end
 
       it 'will get query for given template name with correct match rules and where conditions' do
@@ -81,8 +87,40 @@ RSpec.describe Krane::Report::RiskRule::Query::Builder do
           .with(
             kind: @item[:template],
             matches: "MATCH (ns:Namespace)<-[:SCOPE]-(ro0:Role {is_default: 'false'})" \
-                     "<-[:GRANT]-(ru0:Rule {type: 'resource', resource: '*', verb: 'get'})",
-            where: %Q(ru0.api_group IN ['*'])
+                     "<-[:GRANT]-(ru0:Rule {type: 'resource'})",
+            where: %Q(ru0.api_group IN ['*'] AND ru0.resource IN ['*'] AND ru0.verb IN ['get', '*'] AND ) +
+                   %Q(NOT (ru0.api_group = '*' AND ru0.resource = '*' AND ru0.verb = '*'))
+          ) { tpl }
+
+        subject.for(item: @item)
+      end
+
+    end
+
+    # Non-resource URL rules carry no API group and no resource, so nothing about them can amount
+    # to unrestricted access and the exclusion has no property to match on.
+    context 'for a non-resource URL match rule' do
+
+      let(:risk) do
+        build(
+          :risk, :with_default_template_based_rule,
+          default_rule_match_rules: [
+            {
+              nonResourceURLs: ['/healthz'],
+              verbs: ['get'],
+            }
+          ]
+        )
+      end
+
+      it 'matches the URL as written and does not exclude unrestricted access' do
+        expect(Krane::Report::RiskRule::Query::Template)
+          .to receive(:for)
+          .with(
+            kind: @item[:template],
+            matches: "MATCH (ns:Namespace)<-[:SCOPE]-(ro0:Role {is_default: 'false'})" \
+                     "<-[:GRANT]-(ru0:Rule {type: 'non-resource', url: '/healthz'})",
+            where: %Q(ru0.verb IN ['get', '*'])
           ) { tpl }
 
         subject.for(item: @item)

--- a/spec/lib/krane/report/risk_rule/query/rule_selector_spec.rb
+++ b/spec/lib/krane/report/risk_rule/query/rule_selector_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Krane::Report::RiskRule::Query::RuleSelector do
 
         it 'returns expected array of selectors hashes' do
           expect(subject.selectors).to eq(
-            [{:type=>"resource", :api_groups=>["g1", "g2", "*"], :resource=>"r1"}]
+            [{:type=>"resource", :api_group=>["g1", "g2", "*"], :resource=>["r1", "*"]}]
           )
         end
 
@@ -36,9 +36,27 @@ RSpec.describe Krane::Report::RiskRule::Query::RuleSelector do
 
         it 'returns expected array of selectors hashes' do
           expect(subject.selectors).to include(
-            {:type=>"resource", :api_groups=>["g1", "g2", "*"], :resource=>"r1", :verb=>"get"},
-            {:type=>"resource", :api_groups=>["g1", "g2", "*"], :resource=>"r1", :verb=>"list"}
+            {:type=>"resource", :api_group=>["g1", "g2", "*"], :resource=>["r1", "*"], :verb=>["get", "*"]},
+            {:type=>"resource", :api_group=>["g1", "g2", "*"], :resource=>["r1", "*"], :verb=>["list", "*"]}
           )
+        end
+
+      end
+
+      # Resources and verbs, unlike API groups, are matched together - a role only matches when it
+      # grants all of them - so each stays on its own selector. Only the wildcard joins it there.
+      context 'with several resources and verbs specified' do
+
+        let(:attrs) do
+          {
+            apiGroups: ['rbac.authorization.k8s.io'],
+            resources: ['rolebindings'],
+            verbs: ['patch', 'get']
+          }
+        end
+
+        it 'returns one selector per resource and verb combination' do
+          expect(subject.selectors.size).to eq 2
         end
 
       end
@@ -54,7 +72,7 @@ RSpec.describe Krane::Report::RiskRule::Query::RuleSelector do
 
         it 'matches the `core` group the graph stores for it' do
           expect(subject.selectors).to eq(
-            [{:type=>"resource", :api_groups=>["core", "*"], :resource=>"secrets"}]
+            [{:type=>"resource", :api_group=>["core", "*"], :resource=>["secrets", "*"]}]
           )
         end
 
@@ -71,7 +89,45 @@ RSpec.describe Krane::Report::RiskRule::Query::RuleSelector do
 
         it 'matches the wildcard group only' do
           expect(subject.selectors).to eq(
-            [{:type=>"resource", :api_groups=>["*"], :resource=>"*"}]
+            [{:type=>"resource", :api_group=>["*"], :resource=>["*"]}]
+          )
+        end
+
+      end
+
+      # Issue #529: a role rule granting `verbs: ['*']` grants the named verb, and one granting
+      # `resources: ['*']` covers the named resource, so both have to match.
+      context 'with a resource and a verb named' do
+
+        let(:attrs) do
+          {
+            apiGroups: ['apps'],
+            resources: ['daemonsets'],
+            verbs: ['create']
+          }
+        end
+
+        it 'accepts the wildcard alongside each of them' do
+          expect(subject.selectors).to eq(
+            [{:type=>"resource", :api_group=>["apps", "*"], :resource=>["daemonsets", "*"], :verb=>["create", "*"]}]
+          )
+        end
+
+      end
+
+      context 'with the wildcard resource and verb specified' do
+
+        let(:attrs) do
+          {
+            apiGroups: ['*'],
+            resources: ['*'],
+            verbs: ['*']
+          }
+        end
+
+        it 'does not repeat the wildcard' do
+          expect(subject.selectors).to eq(
+            [{:type=>"resource", :api_group=>["*"], :resource=>["*"], :verb=>["*"]}]
           )
         end
 
@@ -88,7 +144,7 @@ RSpec.describe Krane::Report::RiskRule::Query::RuleSelector do
 
         it 'leaves the API group unconstrained' do
           expect(subject.selectors).to eq(
-            [{:type=>"resource", :resource=>"r1", :verb=>"get"}]
+            [{:type=>"resource", :resource=>["r1", "*"], :verb=>["get", "*"]}]
           )
         end
 
@@ -98,6 +154,8 @@ RSpec.describe Krane::Report::RiskRule::Query::RuleSelector do
 
     context 'for non-resource URL rules' do
 
+      # RBAC matches a non-resource URL by prefix, so `*` is only one of the patterns that can
+      # cover a given URL. The URL is matched as written; the verb still accepts the wildcard.
       context 'with nonResourceURLs specified' do
 
         let(:attrs) do
@@ -126,10 +184,10 @@ RSpec.describe Krane::Report::RiskRule::Query::RuleSelector do
 
         it 'returns expected array of selectors hashes' do
           expect(subject.selectors).to include(
-            {:type=>"non-resource", :url=>"u1", :verb=>"get"},
-            {:type=>"non-resource", :url=>"u1", :verb=>"list"},
-            {:type=>"non-resource", :url=>"u2", :verb=>"get"},
-            {:type=>"non-resource", :url=>"u2", :verb=>"list"}          
+            {:type=>"non-resource", :url=>"u1", :verb=>["get", "*"]},
+            {:type=>"non-resource", :url=>"u1", :verb=>["list", "*"]},
+            {:type=>"non-resource", :url=>"u2", :verb=>["get", "*"]},
+            {:type=>"non-resource", :url=>"u2", :verb=>["list", "*"]}
           )
         end
 


### PR DESCRIPTION
Fixes #529.

## What is wrong

A risk rule's match rules name a resource and a verb. The generated query selected a Rule node by exact equality on both, so a role rule granting the RBAC wildcard in their place was not matched, even though it grants what the rule asks for.

This is the opposite of #80. That issue was about a match rule being too broad; this one is about it being too narrow.

On a test cluster:

- a ClusterRole granting `verbs: ['*']` on secrets was reported by `risky-any-verb-secrets`, but not by `risky-get-secrets` or `risky-list-secrets`
- a ClusterRole granting `get, list, delete` on `resources: ['*']` in the core group was reported by nothing at all, because the fix for #80 scopes the `*` resource rules to the `*` API group
- two escalation paths were missed entirely: a role granting every verb on rolebindings plus `bind` on roles satisfied neither `risky-create-rolebinding-role` nor `risky-add-rolebinding`, and a role granting every verb on `pods/exec` was missed by `risky-exec-pods`

## What changed

The wildcard is now accepted alongside whatever a match rule names, in the same way the API groups already are.

A resource and a verb stay one per selector, because their values are matched together and a role only matches when it grants all of them. Only the wildcard joins each of them.

A selector value is now either a single value the Rule property must equal, or a list of alternatives. The builder tells them apart by shape rather than by name, and the `:api_groups` key becomes `:api_group` so that it matches the property it tests.

`nonResourceURLs` are left as written. RBAC matches a URL by prefix, so `*` is only one of the patterns that can cover a URL, and singling it out would be arbitrary.

## The grant left out

A role rule granting every verb on every resource of the `*` API group is excluded.

Such a role can do anything. That is not a specific risk to report against a named resource and verb, and `unrestricted-cluster-wide-subjects` and `unrestricted-ns-level-subjects` already report it in those words, for every subject it reaches. Without the exclusion a role of that shape turns up under every risky-role rule there is, 46 findings per role on the test cluster, which buries the findings a reader can act on.

A role rule that names an API group is not excluded, `core` included. It grants nothing outside that group, so the resources it does cover are worth naming. Excluding `core` as well was measured and rejected: it hid 12 accurate findings, and left `core: */*` reporting once while `apps: */*` reported 12 times. Only the choice of groups the subject templates happen to cover would justify that difference.

## Testing

Against a kind cluster carrying operator, team and CI RBAC, plus the wildcard shapes from the issue:

- 30 findings before, 73 after, none lost
- all three cases in the issue now report as the issue expects
- `apps: */*` still reports 12 findings; `*/*/*` is kept out of the risky-role rules but still reported for its subjects
- with `RISK_RULE_QUERY_EXCLUDE_DEFAULT_ROLES=false`, `cluster-admin` is left out and `admin` and `edit` report as before
- overriding `match_rules` in `custom-rules.yaml` still works, including a rule matching on `nonResourceURLs`
- the dashboard serves all 73 findings

286 examples pass. The new guards were checked by breaking the code on purpose: removing the exclusion fails 3 of them, dropping the verb widening fails 9, dropping the resource widening fails 10.

## Worth knowing

The report gets longer. Most of that is real coverage, but a `core: */*` role is now reported both for its subjects and under 13 risky-role titles.

The risk rule queries take a bit longer. 
