### PR TITLE
Ingest the RBAC graph in batches, not as a single CREATE

### DIFF
--- a/lib/krane/rbac/graph/builder.rb
+++ b/lib/krane/rbac/graph/builder.rb
@@ -51,6 +51,17 @@ module Krane
         ALL_NAMESPACES_PLACEHOLDER = '*'
         NODE_LABEL_PREFIX = 'n'
 
+        # Node property carrying the node's label. Edges are created by statements of
+        # their own and match their nodes back through it.
+        NODE_KEY = :_id
+
+        # Maximum number of nodes, or relationships, a single ingest statement carries.
+        # A statement holding the whole graph costs FalkorDB memory wildly out of
+        # proportion to the data - a 697 KB statement peaked at 529 MB against a graph
+        # that occupies 8.6 MB once it exists, well over the 200Mi the chart and the
+        # compose file both cap it at.
+        INGEST_BATCH_SIZE = 500
+
         # RBAC kinds which are namespace scoped. Objects of these kinds are only unique
         # within a namespace, so the namespace must form part of their graph node identity.
         # Without it, same-named objects in different namespaces collapse into a single
@@ -97,13 +108,6 @@ module Krane
             yield(i)
           end
           nil
-        end
-
-        # Returns RBAC graph body to be indexed in Graph database
-        #
-        # @return [String]
-        memoize def body
-          (nodes + edges).join(',')
         end
 
         # Returns RBAC graph body for the network view

--- a/lib/krane/rbac/graph/concerns/edges.rb
+++ b/lib/krane/rbac/graph/concerns/edges.rb
@@ -55,6 +55,14 @@ module Krane
               end
             end
 
+            # Edges left out of the graph because an endpoint was never buffered as a
+            # node. Populated by #edge_statements.
+            #
+            # @return [Array<Edge>]
+            def skipped_edges
+              @skipped_edges ||= []
+            end
+
             # Maps graph buffer RBAC edges to network representation
             # 
             # @return [Array]
@@ -67,15 +75,24 @@ module Krane
             # Buffered edges keyed by the node kinds they connect, the relation and its
             # direction, mapping to the pairs of node labels related that way.
             #
-            # Edges whose endpoints were never buffered as nodes are dropped - there is
-            # nothing in the graph for them to attach to.
+            # An edge whose endpoint was never buffered as a node is recorded in
+            # #skipped_edges and left out. It means the cluster's RBAC refers to
+            # something it never defines - a role granting use of a PodSecurityPolicy
+            # that does not exist, say. The single CREATE this replaced turned such an
+            # endpoint into a node with no label and no properties, which every query
+            # binds its nodes by label and so none of them could ever match.
             #
             # @return [Hash]
             def grouped_edges
+              @skipped_edges = []
+
               @edge_buffer.each_with_object(Hash.new {|h,k| h[k] = [] }) do |e, grouped|
                 source_kind      = node_kind_lookup[e.source_label]
                 destination_kind = node_kind_lookup[e.destination_label]
-                next unless source_kind && destination_kind
+                if source_kind.nil? || destination_kind.nil?
+                  @skipped_edges << e
+                  next
+                end
 
                 e.directions.each do |direction|
                   grouped[[source_kind, e.relation, destination_kind, direction]] <<

--- a/lib/krane/rbac/graph/concerns/edges.rb
+++ b/lib/krane/rbac/graph/concerns/edges.rb
@@ -26,11 +26,33 @@ module Krane
           included do
             extend Memoist
 
-            # Maps graph buffer RBAC edges to string representation
-            # 
-            # @return [Array]
-            memoize def edges
-              @edge_buffer.map(&:to_s).compact
+            # Cypher statements creating every buffered RBAC edge, holding at most
+            # `batch_size` relationships each.
+            #
+            # Nodes are created by their own statements, so an edge cannot be written as
+            # a pattern over query scoped variables any more - it has to match both of
+            # its nodes back first. Edges are grouped by everything a single pattern
+            # fixes (the kind of node at either end, the relation and its direction), so
+            # each statement reduces to one UNWIND over the node labels it links.
+            #
+            # @param batch_size [Integer] - maximum number of relationships per statement
+            #
+            # @return [Array<String>]
+            def edge_statements batch_size: Builder::INGEST_BATCH_SIZE
+              grouped_edges.flat_map do |(source_kind, relation, destination_kind, direction), labels|
+                pattern = direction == '->' ?
+                  %Q((s)-[:#{relation}]->(d)) :
+                  %Q((s)<-[:#{relation}]-(d))
+
+                labels.each_slice(batch_size).map do |batch|
+                  pairs = batch.map {|source, destination| "['#{source}','#{destination}']" }.join(',')
+
+                  "UNWIND [#{pairs}] AS pair " \
+                  "MATCH (s:#{source_kind} {#{Builder::NODE_KEY}: pair[0]}), " \
+                        "(d:#{destination_kind} {#{Builder::NODE_KEY}: pair[1]}) " \
+                  "CREATE #{pattern}"
+                end
+              end
             end
 
             # Maps graph buffer RBAC edges to network representation
@@ -41,6 +63,26 @@ module Krane
             end
 
             private
+
+            # Buffered edges keyed by the node kinds they connect, the relation and its
+            # direction, mapping to the pairs of node labels related that way.
+            #
+            # Edges whose endpoints were never buffered as nodes are dropped - there is
+            # nothing in the graph for them to attach to.
+            #
+            # @return [Hash]
+            def grouped_edges
+              @edge_buffer.each_with_object(Hash.new {|h,k| h[k] = [] }) do |e, grouped|
+                source_kind      = node_kind_lookup[e.source_label]
+                destination_kind = node_kind_lookup[e.destination_label]
+                next unless source_kind && destination_kind
+
+                e.directions.each do |direction|
+                  grouped[[source_kind, e.relation, destination_kind, direction]] <<
+                    [e.source_label, e.destination_label]
+                end
+              end
+            end
 
             # Add relation (Edge) between two nodes to the graph edge buffer
             #

--- a/lib/krane/rbac/graph/concerns/nodes.rb
+++ b/lib/krane/rbac/graph/concerns/nodes.rb
@@ -26,11 +26,23 @@ module Krane
           included do
             extend Memoist
 
-            # Maps graph buffer RBAC nodes to string representation
-            # 
-            # @return [Array]
-            memoize def nodes
-              @node_buffer.map(&:to_s).compact
+            # Cypher statements creating every buffered RBAC node, holding at most
+            # `batch_size` nodes each.
+            #
+            # @param batch_size [Integer] - maximum number of nodes per statement
+            #
+            # @return [Array<String>]
+            def node_statements batch_size: Builder::INGEST_BATCH_SIZE
+              @node_buffer.each_slice(batch_size).map do |batch|
+                "CREATE #{batch.map(&:to_s).join(',')}"
+              end
+            end
+
+            # The distinct kinds of node the graph holds
+            #
+            # @return [Array<Symbol>]
+            memoize def node_kinds
+              @node_buffer.map(&:kind).uniq
             end
 
             # Maps graph buffer RBAC nodes to network representation
@@ -48,6 +60,15 @@ module Krane
             end
 
             private
+
+            # Maps every node label to the kind of node it labels. Edge statements match
+            # their nodes back by label once the nodes exist, and need the kind to do so
+            # against the label scoped index rather than the whole graph.
+            #
+            # @return [Hash]
+            memoize def node_kind_lookup
+              @node_buffer.each_with_object({}) {|n, lookup| lookup[n.label] = n.kind }
+            end
 
             # Add node of given kind to the graph node buffer
             #

--- a/lib/krane/rbac/graph/edge.rb
+++ b/lib/krane/rbac/graph/edge.rb
@@ -23,14 +23,15 @@ module Krane
         property :destination_label, required: true
         property :direction,         required: true
 
-        # Returns string representation of an RBAC edge
+        # The directions this edge relates its two nodes in. A bidirectional edge
+        # ('<->') stands for a relationship each way, so it yields both.
         #
-        # @return [String]
-        def to_s
-          out = []
-          out << %Q((#{source_label})-[:#{relation}]->(#{destination_label})) if direction.include?('->')
-          out << %Q((#{source_label})<-[:#{relation}]-(#{destination_label})) if direction.include?('<-')
-          out.join(',')
+        # @return [Array<String>]
+        def directions
+          [].tap do |out|
+            out << '->' if direction.include?('->')
+            out << '<-' if direction.include?('<-')
+          end
         end
 
         # Returns network representation of an RBAC edge

--- a/lib/krane/rbac/graph/node.rb
+++ b/lib/krane/rbac/graph/node.rb
@@ -37,12 +37,19 @@ module Krane
           is_composite:  30
         }
 
-        # Returns string representation of an RBAC node
+        # Returns string representation of an RBAC node, as a clause for a CREATE
+        # statement.
+        #
+        # The node's label is carried as a property rather than as a query scoped
+        # variable, because nodes and edges are no longer created by the same
+        # statement - the edge statements have to match these nodes back afterwards,
+        # and the label is the only stable identity they share.
         #
         # @return [String]
         def to_s
-          node_attrs = attrs.map {|k,v| "#{k.to_s}:'#{v.to_s}'"}.join(", ")
-          %Q((#{label}:#{kind} {#{node_attrs}}))
+          node_attrs = attrs.merge(Builder::NODE_KEY => label)
+                            .map {|k,v| "#{k.to_s}:'#{v.to_s}'"}.join(", ")
+          %Q((:#{kind} {#{node_attrs}}))
         end
 
         # Returns network representation of an RBAC node

--- a/lib/krane/rbac/ingest.rb
+++ b/lib/krane/rbac/ingest.rb
@@ -71,13 +71,7 @@ module Krane
           cluster_role_bindings
         end
 
-        banner :debug, "Graph size = #{graph.body.bytesize} bytes" if @options.debug
-
-        @graph.query(%Q(CREATE #{graph.body}))
-        @graph.query(%Q(CREATE INDEX ON :Namespace(name)))
-        @graph.query(%Q(CREATE INDEX ON :Subject(name)))
-        @graph.query(%Q(CREATE INDEX ON :Role(name)))
-        @graph.query(%Q(CREATE INDEX ON :Rule(name)))
+        create_graph graph
 
         {
           undefined_roles:          graph.undefined_roles,
@@ -86,6 +80,65 @@ module Krane
           rbac_graph_network_nodes: graph.network_nodes,
           rbac_graph_network_edges: graph.network_edges
         }
+      end
+
+      # Writes the built graph out to FalkorDB: the nodes first, then the indexes the
+      # edge statements match those nodes back through, then the edges.
+      #
+      # This is issued as a series of batched statements rather than the single
+      # `CREATE <whole graph>` it replaced, which cost FalkorDB hundreds of megabytes
+      # to parse and apply - enough to have it killed under the memory limit krane
+      # ships with, on a cluster no larger than a few hundred roles.
+      #
+      # Batching gives up that statement's atomicity, so a failure part way through
+      # would otherwise leave a partial graph behind for the report to read as if it
+      # were complete. Discard it and let the failure surface.
+      #
+      # @param graph [Graph::Builder] the built RBAC graph
+      #
+      # @return [nil]
+      def create_graph graph
+        node_statements = graph.node_statements
+        edge_statements = graph.edge_statements
+
+        if @options.debug
+          banner :debug, "Graph size = #{(node_statements + edge_statements).sum(&:bytesize)} bytes " \
+                         "in #{node_statements.size} node and #{edge_statements.size} edge statements"
+        end
+
+        node_statements.each {|statement| @graph.query(statement) }
+        create_indexes graph.node_kinds
+        edge_statements.each {|statement| @graph.query(statement) }
+
+        nil
+      rescue StandardError
+        discard_graph
+        raise
+      end
+
+      # @param node_kinds [Array<Symbol>] the kinds of node the graph holds
+      #
+      # @return [nil]
+      def create_indexes node_kinds
+        node_kinds.each do |kind|
+          @graph.query(%Q(CREATE INDEX ON :#{kind}(#{Graph::Builder::NODE_KEY})))
+        end
+
+        @graph.query(%Q(CREATE INDEX ON :Namespace(name)))
+        @graph.query(%Q(CREATE INDEX ON :Subject(name)))
+        @graph.query(%Q(CREATE INDEX ON :Role(name)))
+        @graph.query(%Q(CREATE INDEX ON :Rule(name)))
+
+        nil
+      end
+
+      # Removes whatever a failed ingest managed to create.
+      #
+      # @return [nil]
+      def discard_graph
+        @graph.delete
+      rescue Clients::FalkorDB::Graph::DeleteError
+        nil # nothing was created, so there is nothing to discard
       end
 
       # PodSecurityPolicies are only fetched and indexed for clusters that still serve them.

--- a/lib/krane/rbac/ingest.rb
+++ b/lib/krane/rbac/ingest.rb
@@ -106,6 +106,8 @@ module Krane
                          "in #{node_statements.size} node and #{edge_statements.size} edge statements"
         end
 
+        report_skipped_edges graph.skipped_edges
+
         node_statements.each {|statement| @graph.query(statement) }
         create_indexes graph.node_kinds
         edge_statements.each {|statement| @graph.query(statement) }
@@ -114,6 +116,23 @@ module Krane
       rescue StandardError
         discard_graph
         raise
+      end
+
+      # An edge can name an entity the cluster never defines - a role granting use of
+      # a PodSecurityPolicy that does not exist, say. Such an edge is left out of the
+      # graph, which is worth saying out loud rather than passing over in silence.
+      #
+      # @param skipped [Array<Graph::Edge>] the edges left out
+      #
+      # @return [nil]
+      def report_skipped_edges skipped
+        return nil if skipped.empty?
+
+        relations = skipped.map(&:relation).tally.map {|relation, count| "#{relation} x#{count}" }.join(', ')
+        banner :warn, "Left #{skipped.size} graph edge(s) out, as they refer to an entity " \
+                      "the cluster never defines (#{relations})."
+
+        nil
       end
 
       # @param node_kinds [Array<Symbol>] the kinds of node the graph holds
@@ -134,11 +153,16 @@ module Krane
 
       # Removes whatever a failed ingest managed to create.
       #
+      # Swallows anything that goes wrong here. Whatever failed the ingest is the
+      # useful diagnostic, and it is raised by the caller once this returns - a tidy
+      # up that fails in turn, because nothing was created yet or because the graph
+      # went away with the connection, must not take its place.
+      #
       # @return [nil]
       def discard_graph
         @graph.delete
-      rescue Clients::FalkorDB::Graph::DeleteError
-        nil # nothing was created, so there is nothing to discard
+      rescue StandardError
+        nil
       end
 
       # PodSecurityPolicies are only fetched and indexed for clusters that still serve them.

--- a/spec/lib/krane/rbac/graph/concerns/edges_spec.rb
+++ b/spec/lib/krane/rbac/graph/concerns/edges_spec.rb
@@ -123,6 +123,12 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Edges do
         expect(subject.edge_statements).to be_empty
       end
 
+      it 'records it, so the drop is not silent' do
+        subject.edge_statements
+
+        expect(subject.skipped_edges).to eq edges
+      end
+
     end
 
     context 'without any edge in the buffer' do
@@ -131,6 +137,12 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Edges do
 
       it 'returns no statements' do
         expect(subject.edge_statements).to be_empty
+      end
+
+      it 'records nothing as skipped' do
+        subject.edge_statements
+
+        expect(subject.skipped_edges).to be_empty
       end
 
     end

--- a/spec/lib/krane/rbac/graph/concerns/edges_spec.rb
+++ b/spec/lib/krane/rbac/graph/concerns/edges_spec.rb
@@ -24,31 +24,113 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Edges do
     Krane::Rbac::Graph::Builder.new path: '/some-path', options: OpenStruct.new(verbose: false)
   end
 
-  describe '#edges' do
+  describe '#edge_statements' do
 
-    context 'with egde buffer present' do
+    # Edges match their nodes back by label, so the nodes have to be in the buffer for
+    # the edge to know what kind of node sits at either end of it.
+    let(:source)      { build(:node, :subject, label: 'n1') }
+    let(:destination) { build(:node, :namespace, label: 'n2') }
 
-      let(:direction) { '->' }
-      let(:edges) { build_list(:edge, 1, direction: direction) }
+    before do
+      subject.instance_variable_set(:@node_buffer, [source, destination])
+      subject.instance_variable_set(:@edge_buffer, edges)
+    end
+
+    context 'with edge buffer present' do
+
+      let(:edges) do
+        [build(:edge, :access, direction: '->', source_label: 'n1', destination_label: 'n2')]
+      end
+
+      it 'matches both nodes back by label and creates the relationship between them' do
+        expect(subject.edge_statements).to eq [
+          "UNWIND [['n1','n2']] AS pair " \
+          "MATCH (s:Subject {_id: pair[0]}), (d:Namespace {_id: pair[1]}) " \
+          "CREATE (s)-[:ACCESS]->(d)"
+        ]
+      end
+
+    end
+
+    context 'with a bidirectional edge' do
+
+      let(:edges) do
+        [build(:edge, :access, direction: '<->', source_label: 'n1', destination_label: 'n2')]
+      end
+
+      it 'creates a relationship in each direction' do
+        statements = subject.edge_statements
+
+        expect(statements.size).to eq 2
+        expect(statements).to include(a_string_ending_with("CREATE (s)-[:ACCESS]->(d)"))
+        expect(statements).to include(a_string_ending_with("CREATE (s)<-[:ACCESS]-(d)"))
+      end
+
+    end
+
+    context 'with edges of differing relation, direction or node kinds' do
+
+      let(:other) { build(:node, :role, label: 'n3') }
+      let(:edges) do
+        [
+          build(:edge, :access, direction: '->', source_label: 'n1', destination_label: 'n2'),
+          build(:edge, :assign, direction: '->', source_label: 'n3', destination_label: 'n1')
+        ]
+      end
 
       before do
+        subject.instance_variable_set(:@node_buffer, [source, destination, other])
         subject.instance_variable_set(:@edge_buffer, edges)
       end
 
-      it 'maps all elements in buffer to their string representation' do
-        res = subject.edges
-        e   = edges.first 
-        expect(res).to include(
-          "(#{e.source_label})-[:#{e.relation}]#{direction}(#{e.destination_label})"
-        )
+      it 'keeps them in separate statements, as one pattern cannot express both' do
+        expect(subject.edge_statements.size).to eq 2
+      end
+
+    end
+
+    context 'with more edges sharing a pattern than fit in a batch' do
+
+      let(:edges) do
+        3.times.map {|i| build(:edge, :access, direction: '->', source_label: 'n1', destination_label: 'n2') }
+      end
+
+      before do
+        # Edge is a Hashie::Dash, so identical edges collapse in the real Set buffer -
+        # an Array keeps all three, which is what the batching is being exercised on.
+        subject.instance_variable_set(:@edge_buffer, edges)
+      end
+
+      it 'splits them across statements of at most the batch size' do
+        statements = subject.edge_statements batch_size: 2
+
+        expect(statements.size).to eq 2
+        expect(statements.map {|s| s.scan(/\['n1','n2'\]/).size }).to eq [2, 1]
+      end
+
+    end
+
+    # A binding can reference a role that no node was ever built for. There is nothing
+    # in the graph to attach such an edge to, and matching it back would silently
+    # create empty nodes.
+    context 'with an edge whose endpoint was never added as a node' do
+
+      let(:edges) do
+        [build(:edge, :access, direction: '->', source_label: 'n1', destination_label: 'unknown')]
+      end
+
+      it 'drops the edge' do
+        expect(subject.edge_statements).to be_empty
       end
 
     end
 
     context 'without any edge in the buffer' do
 
-      it 'returns empty Set' do
-        expect(subject.edges).to be_empty
+      let(:edges) { [] }
+
+      it 'returns no statements' do
+        expect(subject.edge_statements).to be_empty
       end
 
     end

--- a/spec/lib/krane/rbac/graph/concerns/nodes_spec.rb
+++ b/spec/lib/krane/rbac/graph/concerns/nodes_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Nodes do
     Krane::Rbac::Graph::Builder.new path: '/some-path', options: OpenStruct.new(verbose: false)
   end
 
-  describe '#nodes' do
+  describe '#node_statements' do
 
     context 'with nodes buffer present' do
 
@@ -15,21 +15,62 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Nodes do
         subject.instance_variable_set(:@node_buffer, nodes)
       end
 
-      it 'maps all elements in buffer to their string representation' do
-        res  = subject.nodes
-        node = nodes.first 
-        expected_attrs = node.attrs.map {|k,v| "#{k.to_s}:'#{v.to_s}'"}.join(", ")
-        expect(res).to include(
-          "(#{node.label}:#{node.kind} {#{expected_attrs}})"
-        )
+      it 'maps all elements in buffer to a CREATE statement' do
+        node = nodes.first
+        expect(subject.node_statements).to eq ["CREATE #{node}"]
+      end
+
+    end
+
+    # The whole graph in one statement is what costs FalkorDB the memory this batching
+    # exists to avoid, so the batch size has to be an upper bound on every statement.
+    context 'with more nodes in the buffer than fit in a batch' do
+
+      let(:nodes) { build_list(:node, 5) }
+
+      before do
+        subject.instance_variable_set(:@node_buffer, nodes)
+      end
+
+      it 'splits them across statements of at most the batch size' do
+        statements = subject.node_statements batch_size: 2
+
+        expect(statements.size).to eq 3
+        expect(statements.map {|s| s.scan(/:Role \{/).size }).to eq [2, 2, 1]
       end
 
     end
 
     context 'without any node in the buffer' do
 
-      it 'returns empty Set' do
-        expect(subject.nodes).to be_empty
+      it 'returns no statements' do
+        expect(subject.node_statements).to be_empty
+      end
+
+    end
+
+  end
+
+  describe '#node_kinds' do
+
+    context 'with nodes buffer present' do
+
+      let(:nodes) { build_list(:node, 2, :role) + build_list(:node, 1, :namespace) }
+
+      before do
+        subject.instance_variable_set(:@node_buffer, nodes)
+      end
+
+      it 'returns the distinct kinds of node the graph holds' do
+        expect(subject.node_kinds).to contain_exactly(:Role, :Namespace)
+      end
+
+    end
+
+    context 'without any node in the buffer' do
+
+      it 'returns no kinds' do
+        expect(subject.node_kinds).to be_empty
       end
 
     end

--- a/spec/lib/krane/rbac/graph/concerns/roles_spec.rb
+++ b/spec/lib/krane/rbac/graph/concerns/roles_spec.rb
@@ -338,11 +338,12 @@ RSpec.describe Krane::Rbac::Graph::Concerns::Roles do
           expect(grant_sources.tally.values).to all(eq 1)
         end
 
-        it 'does not bind the same graph variable twice in the CREATE statement' do
-          # openCypher forbids redeclaring a bound variable within a single CREATE.
-          declared = subject.send(:nodes).join(',').scan(/\((n\d+):Role/).flatten
+        it 'gives each of them a distinct node key in the CREATE statements' do
+          # The node key is what edges match a node back through, so two Roles sharing
+          # one would have their edges land on whichever node matched first.
+          keys = subject.node_statements.join(',').scan(/\(:Role \{.*?_id:'(\w+)'\}\)/).flatten
 
-          expect(declared).to eq declared.uniq
+          expect(keys).to eq keys.uniq
         end
 
         it 'tracks every namespace the Role name is defined in' do

--- a/spec/lib/krane/rbac/graph/edge_spec.rb
+++ b/spec/lib/krane/rbac/graph/edge_spec.rb
@@ -29,14 +29,14 @@ RSpec.describe Krane::Rbac::Graph::Edge do
 
   end
 
-  describe '#to_s' do
+  describe '#directions' do
 
     context 'for source node referencing destination node (direction: ->)' do
 
       subject { build(:edge, direction: '->') }
 
-      it 'returns string representation of the edge to be indexed in the graph' do
-        expect(subject.to_s).to eq %Q((#{subject.source_label})-[:#{subject.relation}]->(#{subject.destination_label}))
+      it 'relates the nodes one way only' do
+        expect(subject.directions).to eq ['->']
       end
 
     end
@@ -45,8 +45,8 @@ RSpec.describe Krane::Rbac::Graph::Edge do
 
       subject { build(:edge, direction: '<-') }
 
-      it 'returns string representation of the edge to be indexed in the graph' do
-        expect(subject.to_s).to eq %Q((#{subject.source_label})<-[:#{subject.relation}]-(#{subject.destination_label}))
+      it 'relates the nodes one way only' do
+        expect(subject.directions).to eq ['<-']
       end
 
     end
@@ -55,11 +55,8 @@ RSpec.describe Krane::Rbac::Graph::Edge do
 
       subject { build(:edge, direction: '<->') }
 
-      it 'returns string representation of the edge to be indexed in the graph' do
-        expect(subject.to_s).to eq [
-          %Q((#{subject.source_label})-[:#{subject.relation}]->(#{subject.destination_label})),
-          %Q((#{subject.source_label})<-[:#{subject.relation}]-(#{subject.destination_label}))
-        ].join(',')
+      it 'stands for a relationship each way' do
+        expect(subject.directions).to eq ['->', '<-']
       end
 
     end

--- a/spec/lib/krane/rbac/graph/node_spec.rb
+++ b/spec/lib/krane/rbac/graph/node_spec.rb
@@ -35,7 +35,14 @@ RSpec.describe Krane::Rbac::Graph::Node do
 
     it 'returns string representation of the node to be indexed in the graph' do
       expected_attrs = subject.attrs.map {|k,v| "#{k.to_s}:'#{v.to_s}'"}.join(", ")
-      expect(subject.to_s).to eq %Q((#{subject.label}:#{subject.kind} {#{expected_attrs}}))
+      expect(subject.to_s).to eq %Q((:#{subject.kind} {#{expected_attrs}, _id:'#{subject.label}'}))
+    end
+
+    # The node's label is not a query scoped variable any more - edges are created by
+    # statements of their own and match their nodes back through this property.
+    it 'carries the node label as a property rather than as a bound variable' do
+      expect(subject.to_s).to include "#{Krane::Rbac::Graph::Builder::NODE_KEY}:'#{subject.label}'"
+      expect(subject.to_s).not_to start_with "(#{subject.label}:"
     end
 
   end

--- a/spec/lib/krane/rbac/ingest_spec.rb
+++ b/spec/lib/krane/rbac/ingest_spec.rb
@@ -146,9 +146,13 @@ RSpec.describe Krane::Rbac::Ingest do
 
     describe '#index_rbac' do
 
+      let(:node_statements) { ['CREATE (:Role {_id:\'n1\'})', 'CREATE (:Namespace {_id:\'n2\'})'] }
+      let(:edge_statements) { ['UNWIND [[\'n1\',\'n2\']] AS pair ... CREATE (s)-[:SCOPE]->(d)'] }
       let(:build_graph_results) do 
         double( :graph, 
-          body: 'graph body...',
+          node_statements: node_statements,
+          edge_statements: edge_statements,
+          node_kinds: [:Role, :Namespace],
           undefined_roles: ['set of undefined roles'],
           unused_roles: ['set of unused roles'],
           bindings_without_subject: ['set of bindings without subject'],
@@ -176,7 +180,11 @@ RSpec.describe Krane::Rbac::Ingest do
       it 'will build and index rbac graph, and return a results map' do
         expect(@instance).to receive(:build_graph).with(dir) { build_graph_results }
 
-        expect(graph_client).to receive(:query).with(%Q(CREATE #{build_graph_results.body}))
+        (node_statements + edge_statements).each do |statement|
+          expect(graph_client).to receive(:query).with(statement)
+        end
+        expect(graph_client).to receive(:query).with(%Q(CREATE INDEX ON :Role(_id)))
+        expect(graph_client).to receive(:query).with(%Q(CREATE INDEX ON :Namespace(_id)))
         expect(graph_client).to receive(:query).with(%Q(CREATE INDEX ON :Namespace(name)))
         expect(graph_client).to receive(:query).with(%Q(CREATE INDEX ON :Subject(name)))
         expect(graph_client).to receive(:query).with(%Q(CREATE INDEX ON :Role(name)))
@@ -191,6 +199,81 @@ RSpec.describe Krane::Rbac::Ingest do
           rbac_graph_network_nodes: build_graph_results.network_nodes,
           rbac_graph_network_edges: build_graph_results.network_edges
         )
+      end
+
+      # The edge statements match nodes back through the node key, and without the index
+      # each one falls back to scanning every node of that kind.
+      it 'will create the node key indexes before issuing any edge statement' do
+        expect(@instance).to receive(:build_graph).with(dir) { build_graph_results }
+
+        issued = []
+        allow(graph_client).to receive(:query) {|statement| issued << statement }
+
+        @instance.send(:index_rbac)
+
+        expect(issued.index(%Q(CREATE INDEX ON :Role(_id)))).to be < issued.index(edge_statements.first)
+        expect(issued.index(node_statements.last)).to be < issued.index(%Q(CREATE INDEX ON :Role(_id)))
+      end
+
+    end
+
+    # Batched ingest is no longer atomic - what a failed run already applied stays in the
+    # graph, and the report would read it as a complete picture of the cluster's RBAC.
+    describe '#create_graph' do
+
+      let(:graph) do
+        double( :graph,
+          node_statements: ['CREATE (:Role {_id:\'n1\'})'],
+          edge_statements: [],
+          node_kinds:      [:Role]
+        )
+      end
+      let(:options) { OpenStruct.new(cluster: :default) }
+
+      before do
+        @instance = described_class.new(options)
+      end
+
+      context 'when a statement fails part way through' do
+
+        before do
+          allow(graph_client).to receive(:query).and_raise(
+            Krane::Clients::FalkorDB::Graph::QueryError, 'boom'
+          )
+        end
+
+        it 'discards the partial graph and re-raises' do
+          expect(graph_client).to receive(:delete).once
+
+          expect { @instance.send(:create_graph, graph) }.to raise_error(
+            Krane::Clients::FalkorDB::Graph::QueryError, 'boom'
+          )
+        end
+
+        it 'still re-raises when there is nothing to discard' do
+          allow(graph_client).to receive(:delete).and_raise(
+            Krane::Clients::FalkorDB::Graph::DeleteError, 'no such graph'
+          )
+
+          expect { @instance.send(:create_graph, graph) }.to raise_error(
+            Krane::Clients::FalkorDB::Graph::QueryError, 'boom'
+          )
+        end
+
+      end
+
+      context 'when every statement succeeds' do
+
+        before do
+          allow(graph_client).to receive(:query)
+        end
+
+        it 'leaves the graph in place' do
+          expect(graph_client).to receive(:delete).never
+
+          @instance.send(:create_graph, graph)
+        end
+
       end
 
     end

--- a/spec/lib/krane/rbac/ingest_spec.rb
+++ b/spec/lib/krane/rbac/ingest_spec.rb
@@ -153,6 +153,7 @@ RSpec.describe Krane::Rbac::Ingest do
           node_statements: node_statements,
           edge_statements: edge_statements,
           node_kinds: [:Role, :Namespace],
+          skipped_edges: [],
           undefined_roles: ['set of undefined roles'],
           unused_roles: ['set of unused roles'],
           bindings_without_subject: ['set of bindings without subject'],
@@ -225,7 +226,8 @@ RSpec.describe Krane::Rbac::Ingest do
         double( :graph,
           node_statements: ['CREATE (:Role {_id:\'n1\'})'],
           edge_statements: [],
-          node_kinds:      [:Role]
+          node_kinds:      [:Role],
+          skipped_edges:   []
         )
       end
       let(:options) { OpenStruct.new(cluster: :default) }
@@ -258,6 +260,43 @@ RSpec.describe Krane::Rbac::Ingest do
           expect { @instance.send(:create_graph, graph) }.to raise_error(
             Krane::Clients::FalkorDB::Graph::QueryError, 'boom'
           )
+        end
+
+        # Whatever went wrong with the ingest is the useful diagnostic. A tidy up that
+        # fails in turn - the graph has gone away with the connection, say - must not
+        # take its place.
+        it 'keeps the original failure when discarding the graph fails too' do
+          allow(graph_client).to receive(:delete).and_raise(Redis::CannotConnectError, 'gone')
+
+          expect { @instance.send(:create_graph, graph) }.to raise_error(
+            Krane::Clients::FalkorDB::Graph::QueryError, 'boom'
+          )
+        end
+
+      end
+
+      # A dangling RBAC reference produces one of these. It is left out of the graph,
+      # which the operator should hear about rather than have passed over.
+      context 'when an edge refers to an entity the cluster never defines' do
+
+        let(:skipped) { [build(:edge, :security)] }
+
+        before do
+          allow(graph).to receive(:skipped_edges) { skipped }
+          allow(graph_client).to receive(:query)
+        end
+
+        it 'says so' do
+          expect(@instance).to receive(:banner).with(:warn, /Left 1 graph edge\(s\) out.*SECURITY x1/)
+
+          @instance.send(:create_graph, graph)
+        end
+
+        it 'still ingests the rest of the graph' do
+          allow(@instance).to receive(:banner)
+          expect(graph_client).to receive(:query).with('CREATE (:Role {_id:\'n1\'})')
+
+          @instance.send(:create_graph, graph)
         end
 
       end


### PR DESCRIPTION
**Work in progress.** Closes #525.

## The problem

`Rbac::Ingest#index_rbac` sent the whole cluster graph as one statement:

```ruby
@graph.query(%Q(CREATE #{graph.body}))
```

FalkorDB parses that into a single tree and applies it in one transaction, and the transient cost is far out of proportion to the data it produces.

## Why it was not a one-line change

Edge clauses reference nodes as variables bound in the same statement:

```
CREATE (n1:Namespace {...}),(n2:Role {...}),(n1)<-[:SCOPE]-(n2)
```

Split that across statements and the second one has no `n1`. Sending nodes and edges separately needs a stable key on each node, and an index to match nodes back through.

## What this does

- `Node#to_s` now carries the node's label as an `_id` property instead of binding it as a variable, so nodes are created anonymously: `(:Role {..., _id:'n5'})`.
- `Builder#node_statements` batches nodes into `CREATE` statements of at most 500.
- `Builder#edge_statements` groups edges by everything one pattern fixes — the kind of node at either end, the relation, and its direction — and emits one `UNWIND` per batch:

  ```
  UNWIND [['n5','n1'],...] AS pair
  MATCH (s:Role {_id: pair[0]}), (d:Namespace {_id: pair[1]})
  CREATE (s)-[:SCOPE]->(d)
  ```

  `GRAPH.EXPLAIN` confirms both ends resolve by index scan.
- `Edge#to_s` becomes `Edge#directions`. A bidirectional edge still yields a relationship each way.
- `Ingest#create_graph` runs nodes, then the `_id` indexes, then edges. Batching gives up the single statement's atomicity, so if any statement fails it discards the graph and re-raises, rather than leaving a partial graph for the report to read as a complete picture of the cluster.
- `Builder#body` is removed, since nothing calls it any more.

## Testing

Unit suite: 292 examples, 0 failures.

End to end against FalkorDB v4.20.3 — the version the chart and the compose file both pin — configured the way they configure it (`RESULTSET_SIZE -1`, `BROWSER 0`). Cache: 600 Roles, 510 ClusterRoles, 600 RoleBindings, 510 ClusterRoleBindings across 40 namespaces.

| | master | this branch |
|---|---|---|
| largest single statement | 3.5 MB | 86 KB |
| peak container memory | 373 MiB | 165 MiB |
| ingest wall time | 6.1 s | 2.2 s |
| graph nodes / relationships | 2,488 / 130,260 | 2,488 / 130,260 |

Peak is read from the cgroup's `memory.peak` with no limit applied, so nothing is capped or reclaimed. The chart and the compose file both cap FalkorDB at 200Mi: master's peak is over that, this branch's fits under it.

To be clear about what that does and does not show: master is not reliably killed at 200Mi. Much of its peak is page cache from writing the tree files, which the kernel can reclaim, so it often survives while sitting right on the limit. It *is* killed when the bundled browser is left enabled, which raises the idle footprint. The defensible claim is the peak demand, not the kill.

Output is unchanged. The report JSON is identical (3,484 normalised lines; 15 danger, 20 warning, 2 info, 18 success), as are all 2,821 generated dashboard files apart from the tree manifest's timestamp. Also checked against `cache/default`, which exercises PodSecurityPolicy nodes and `:SECURITY` edges and contains a dangling reference — all 100 files identical there too.

## Worth a look in review

- **`_id` adds a property to every node.** The resident graph grew from 8.6 MB to 9.3 MB on this cluster.
- **The batch size of 500 is a first guess.** It keeps the largest statement at 86 KB here. It has not been tuned across a range.
- **The graph client's 1 s read timeout is untouched.** On master, at this cluster size, the single `CREATE` takes 6 s and the report fails on that timeout before memory even becomes the question. Batching happens to avoid it, because no single statement is slow enough to matter, but the default itself is still fragile and is left for a separate change.

## Edges naming an entity that is never defined

Worth its own note, as it is a real behaviour change.

An edge can name a node the builder never created. In a single `CREATE`, an undeclared variable is simply a fresh node, so the old code silently made an unlabelled, propertyless one for it. Batching cannot do that, and the `MATCH` finds nothing instead.

It is not hypothetical. Three of the seven cached clusters here have one: a ClusterRole granting `use` on a PodSecurityPolicy named `kindnet` that the cluster does not define. That is a dangling reference in the cluster's own RBAC, not a fault in the builder.

Dropping the edge is the better behaviour — every Cypher query in the codebase binds its nodes by label, so the node the old code created could never match one, which is why the reports come out identical. Measured on `cache/default`:

| | master | this branch |
|---|---|---|
| nodes | 802 | 801 |
| relationships | 5,540 | 5,538 |
| unlabelled nodes | 1 | 0 |
| report and dashboard output | — | identical |

What was wrong was doing it quietly. The edges are now collected and reported:

```
WARN: Left 1 graph edge(s) out, as they refer to an entity the cluster never defines (SECURITY x1).
```

Surfacing this as a report finding, alongside the existing "Dangling roles", would be a reasonable follow up. Out of scope here.

## The failure path, exercised for real

No longer only unit tested. A copy of `cache/default` was doctored so a ClusterRole name contains a single quote, which the unescaped value interpolation turns into a Cypher syntax error part way through ingest:

| | graph left behind |
|---|---|
| with the discard removed | `rbac-failtest`, 500 nodes — one node batch |
| as implemented | none |

That partial graph is exactly what the report would otherwise have read as a complete picture of the cluster.

Doing this also turned up a fault in the tidy up. `discard_graph` only rescued `DeleteError`, so if the tidy up failed any other way — the graph having gone with the connection, say — that error replaced the one that caused it, losing the only useful diagnostic. It now swallows everything and lets the caller re-raise the original. Covered by a test that fails without the fix.

Note the unescaped interpolation used to provoke this is a pre-existing weakness, untouched here.

## Related

The two secondary notes in #525 are split out as #532 and #533.
