### PR TITLE
Fix in-cluster startup: probe hang, env parsing, cache dir permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,10 @@ RUN curl -sL -o /usr/bin/kubectl ${KUBECTL_BINARY_URL} && chmod +x /usr/bin/kube
 RUN addgroup -g 1000 -S appuser \
     && adduser -u 1000 -S appuser -G appuser
 
+# WORKDIR creates root-owned dirs regardless of USER (classic builder) - the
+# app needs to write $APP_PATH/cache at runtime
+RUN mkdir -p $APP_PATH/cache && chown -R 1000:1000 $APP_PATH
+
 USER 1000
 
 ENV BUNDLE_PATH=/usr/local/bundle \

--- a/bin/in-cluster-run
+++ b/bin/in-cluster-run
@@ -4,7 +4,9 @@
 : ${KRANE_REPORT_OUTPUT:=none}
 
 echo "Verify FalkorDB is UP..."
-while [[ "$((printf "PING\r\n";) | nc falkordb 6379 -w 2 | awk '{$1=$1};1')" != "+PONG" ]];
+# timeout bounds the whole probe: busybox nc's -w only limits the connect, so a
+# connection established to a dying falkordb pod would otherwise block forever
+while [[ "$((printf "PING\r\n";) | timeout 5 nc falkordb 6379 -w 2 | awk '{$1=$1};1')" != "+PONG" ]];
   do echo "* Waiting for falkordb to become available" && sleep 2;
 done
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,5 +24,5 @@ services:
     entrypoint: ["/bin/bash", "-c", "sleep 86400"]
     # Uncomment volume below if you want to run report against
     # a cluster by passing specific kube context to `report` command.
-    volumes:
-      - ~/.kube/config:/app/.kube/config:ro
+    # volumes:
+    #   - ~/.kube/config:/app/.kube/config:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,9 @@ services:
       KRANE_REPORT_INTERVAL: 30
       KRANE_REPORT_OUTPUT: 'none'
       FALKORDB_HOST: 'falkordb'
+      # Explicit port: in k8s the service-link var FALKORDB_PORT=tcp://<ip>:6379
+      # would otherwise shadow the default and krane fails parsing it as a number
+      FALKORDB_PORT: '6379'
       SLACK_WEBHOOK_URL: ''
       SLACK_CHANNEL: ''
     networks:

--- a/k8s/one-time/prerequisites.yaml
+++ b/k8s/one-time/prerequisites.yaml
@@ -23,6 +23,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: krane-sa
+  # explicit: the ClusterRoleBinding below expects the SA here; without this,
+  # `kubectl apply -f` would create it in the current context's namespace
+  namespace: krane
 automountServiceAccountToken: false
 
 ---


### PR DESCRIPTION
## Summary

Fixes found by deploying the dev environment to a real cluster (docker-desktop, via `tako dev --skaffold`). Each of these breaks in-cluster startup today:

- **`bin/in-cluster-run`** — the FalkorDB probe is now bounded with `timeout 5`. Busybox `nc`'s `-w` only limits the *connect*, so a connection established to a dying falkordb pod (a common race when both pods start together) blocked the check forever without ever retrying — the pod sat on "Verify FalkorDB is UP..." indefinitely.
- **`docker-compose.yml`** — set `FALKORDB_PORT=6379` explicitly. Kubernetes injects the docker-legacy service-link variable `FALKORDB_PORT=tcp://<cluster-ip>:6379` for the falkordb service, and krane fails parsing it as a numeric port (`error: invalid value for Integer()`), killing every report run. An explicit container env var takes precedence over the injected one; harmless in plain docker-compose since 6379 is the default anyway.
- **`Dockerfile`** — create `$APP_PATH/cache` with `appuser` ownership before the `USER` switch. `WORKDIR` creates root-owned directories regardless of `USER` (classic builder), so the report crashed with `Permission denied @ dir_s_mkdir - /app/cache`.
- **`docker-compose.override.yml`** — the host kubeconfig bind mount is now opt-in (commented out, matching the docs around it). In-cluster it is dead weight that converts to an unbindable `ReadOnlyMany` PVC and leaves the pod `Pending`.
- **`k8s/one-time/prerequisites.yaml`** — namespace the ServiceAccount explicitly. The ClusterRoleBinding subject expects `krane-sa` in the `krane` namespace, but without `metadata.namespace` a plain `kubectl apply -f` creates the SA in the current context's namespace and the binding silently never matches — the report then fails with a 403 listing roles.

## Test plan

- [x] Deployed to a local cluster end to end: probe survives the falkordb startup race and retries, report completes (`RBAC fetched from running cluster and stored in cache directory`), dashboard serves on port 8000
- [x] `kubectl auth can-i list roles.rbac.authorization.k8s.io --as=system:serviceaccount:krane:krane-sa` → yes after applying the fixed prerequisites

🤖 Generated with [Claude Code](https://claude.com/claude-code)