### PR TITLE
Fix Cypher injection via unescaped RBAC subject names

### DIFF
--- a/lib/krane/rbac/graph/node.rb
+++ b/lib/krane/rbac/graph/node.rb
@@ -41,7 +41,7 @@ module Krane
         #
         # @return [String]
         def to_s
-          node_attrs = attrs.map {|k,v| "#{k.to_s}:'#{v.to_s}'"}.join(", ")
+          node_attrs = attrs.map {|k,v| "#{k.to_s}:'#{escape(v)}'"}.join(", ")
           %Q((#{label}:#{kind} {#{node_attrs}}))
         end
 
@@ -88,6 +88,17 @@ module Krane
             value: node_weitghs[label],
             title: title
           }
+        end
+
+        private
+
+        # Attribute values carry cluster-supplied strings (e.g. RoleBinding subject
+        # names, which Kubernetes does not format-validate for User/Group kinds) and
+        # are rendered into single-quoted Cypher literals executed verbatim by
+        # Ingest#index_rbac - quotes and backslashes must be escaped here or a
+        # crafted value breaks out of the literal and injects arbitrary Cypher.
+        def escape value
+          value.to_s.gsub(/['\\]/) { |c| "\\#{c}" }
         end
       end
 

--- a/spec/lib/krane/rbac/graph/node_spec.rb
+++ b/spec/lib/krane/rbac/graph/node_spec.rb
@@ -34,8 +34,39 @@ RSpec.describe Krane::Rbac::Graph::Node do
     subject { build(:node) }
 
     it 'returns string representation of the node to be indexed in the graph' do
-      expected_attrs = subject.attrs.map {|k,v| "#{k.to_s}:'#{v.to_s}'"}.join(", ")
-      expect(subject.to_s).to eq %Q((#{subject.label}:#{subject.kind} {#{expected_attrs}}))
+      expect(subject.to_s).to eq %q((label:Role {kind:'Role', name:'example-role'}))
+    end
+
+    # Attribute values carry cluster-supplied strings (e.g. RoleBinding subject names)
+    # rendered into single-quoted Cypher literals - unescaped quotes would let a
+    # crafted value break out of the literal and inject arbitrary Cypher into the
+    # CREATE statement (GHSA-67qw-mcw6-xh54).
+    context 'with attribute values containing Cypher string literal metacharacters' do
+
+      context 'with single quotes and a comment marker in the value' do
+
+        subject do
+          build(:node, :subject, attrs: { kind: :User, name: "x'}) CREATE (:Pwned) //" })
+        end
+
+        it 'escapes single quotes so the value cannot terminate the literal' do
+          expect(subject.to_s).to eq "(label:Subject {kind:'User', name:'x\\'}) CREATE (:Pwned) //'})"
+        end
+
+      end
+
+      context 'with a trailing backslash in the value' do
+
+        subject do
+          build(:node, :subject, attrs: { kind: :User, name: "alice\\" })
+        end
+
+        it 'escapes backslashes so the value cannot escape the closing quote' do
+          expect(subject.to_s).to eq "(label:Subject {kind:'User', name:'alice\\\\'})"
+        end
+
+      end
+
     end
 
   end


### PR DESCRIPTION
## Summary

Fixes a Cypher injection in the RBAC graph ingestion path.

`Krane::Rbac::Graph::Node#to_s` rendered every node attribute as a single-quoted Cypher literal (`#{k}:'#{v}'`) with no escaping, and `Ingest#index_rbac` executes the assembled body verbatim via `GRAPH.QUERY` (`CREATE #{graph.body}`) with no parameter binding. A RoleBinding/ClusterRoleBinding `subjects[].name` — which Kubernetes does **not** format-validate for `User`/`Group` kinds — can contain single quotes and `//`, letting any principal able to create/update a binding break out of the string literal and inject arbitrary Cypher into the `CREATE` statement that seeds krane's security graph (corrupting/truncating RBAC report data and creating attacker-controlled nodes).

## Fix

Escape single quotes and backslashes in `Node#to_s` attribute values. This is the single externally-reachable injection point — the place all cluster-supplied node attribute values (subject names, namespaces) become query text. Node/edge *labels* are already sanitized via `make_label` (`\W` stripping); this was the gap for property *values*.

Other Cypher-building sites were reviewed and intentionally left unchanged: the tree-view query and `CREATE INDEX` calls are static, and the risk-rule query builder interpolates values from the operator's own risk-rules YAML (operator-trusted config, not attacker-controlled cluster data — out of scope for this advisory).

## Testing

- Full suite green (282 examples, 0 failures).
- Added specs for the exact advisory payload plus a trailing-backslash case; rewrote the pre-existing `#to_s` spec that mirrored the vulnerable implementation to assert literal output instead.
- Verified end-to-end against a real `falkordb/falkordb:v4.20.3` container using krane's own `Node` class with the advisory payload: no injected node created, subject name stored intact, generated Cypher escapes the quote inside the literal.